### PR TITLE
per GET/POST übergebene Zahlen prüfen (Ticket 0013)

### DIFF
--- a/admin/allgemein_alpha.php
+++ b/admin/allgemein_alpha.php
@@ -1,8 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.allgemein_alpha.php");
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
         ?>
@@ -41,7 +43,7 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
  }
 
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
         $forum=1;

--- a/admin/allgemein_beta.php
+++ b/admin/allgemein_beta.php
@@ -1,7 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.allgemein_beta.php");
-if ($_GET["fu"]==1) {
+$fuid = int_get('fu');
+
+if ($fuid==1) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
         $zeiger = @mysql_query("SELECT * FROM $skrupel_info");
@@ -125,12 +128,12 @@ if ($_GET["fu"]==1) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-        $chat=$_POST["chat"];
-        $anleitung=$_POST["anleitung"];
-        $forum=$_POST["forum"];
+        $chat=int_post('chat');
+        $anleitung=int_post('anleitung');
+        $forum=int_post('forum');
         $forum_url=$_POST["forum_url"];
         $zeiger = @mysql_query("update $skrupel_info set chat=$chat, anleitung=$anleitung, forum=$forum, forum_url='$forum_url'");
         ?>

--- a/admin/allgemein_gamma.php
+++ b/admin/allgemein_gamma.php
@@ -1,6 +1,9 @@
 <?php 
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.allgemein_gamma.php");
+$fuid = int_get('fu');
+
 $erweiterung[0]['name']='Movie-GIF';
 $erweiterung[0]['ordner']='moviegif';
 $erweiterung[0]['autor']='Skrupel.de';
@@ -21,7 +24,8 @@ $erweiterung[3]['ordner']='xstats';
 $erweiterung[3]['autor']='Stefan Heller';
 $erweiterung[3]['activate']=1;
 $erweiterung[3]['activatepos']=2;
-if ($_GET["fu"]==1) {
+
+if ($fuid==1) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
         $zeiger = @mysql_query("SELECT extend FROM $skrupel_info");
@@ -75,11 +79,11 @@ if ($_GET["fu"]==1) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-        $value=$_GET["value"];
-        $pos=$_GET["pos"];
+        $value=int_get('value');
+        $pos=int_get('pos');
         $zeiger = @mysql_query("SELECT extend FROM $skrupel_info");
         $array = @mysql_fetch_array($zeiger);
         $spiel_extend=$array["extend"];

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -1,7 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.menu.php");
-if ($_GET["fu"]==1) { ?>
+$fuid = int_get('fu');
+
+if ($fuid==1) { ?>
 <?php
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
@@ -132,7 +135,7 @@ if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 </table></center>
 <?php } include ("inc.footer.php"); ?>
 <?php } ?>
-<?php if ($_GET["fu"]==2) { ?>
+<?php if ($fuid==2) { ?>
 <?php
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {

--- a/admin/mitspieler_alpha.php
+++ b/admin/mitspieler_alpha.php
@@ -1,7 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.mitspieler_alpha.php");
-if ($_GET["fu"]==1) {
+$fuid = int_get('fu');
+
+if ($fuid==1) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 ?>
@@ -26,7 +29,7 @@ if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
    </table></form></center>
 <?php } include ("inc.footer.php");
  }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 $nick=$_POST["nick"];

--- a/admin/mitspieler_beta.php
+++ b/admin/mitspieler_beta.php
@@ -1,7 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.mitspieler_beta.php");
-if ($_GET["fu"]==1) {
+$fuid = int_get('fu');
+
+if ($fuid==1) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 ?>

--- a/admin/mitspieler_gamma.php
+++ b/admin/mitspieler_gamma.php
@@ -1,7 +1,10 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.mitspieler_gamma.php");
-if ($_GET["fu"]==1) {
+$fuid = int_get('fu');
+
+if ($fuid==1) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 ?>
@@ -63,10 +66,10 @@ if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 </table></center>
 <?php } include ("inc.footer.php");
  }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-$id=$_GET["spieler_id"];
+$id=int_get('spieler_id');
 $zeiger = @mysql_query("DELETE from $skrupel_user where id=$id");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/admin/spiel_alpha.php
+++ b/admin/spiel_alpha.php
@@ -1,9 +1,12 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 $lang = array();
 include ("../lang/".$language."/lang.admin.spiel_alpha.php");
+$fuid = int_get('fu');
 $prozentarray=array(0,1,2,3,4,5,6,7,8,9,10,15,20,30,40,50,60,70,80,90,100);
-if ($_GET["fu"]==1) {
+
+if ($fuid==1) {
 include ("inc.header.php");
 if (@intval(substr($spiel_extend,1,1))==1) {
     //Wird nur bei installierter, aktiver KI ausgefuehrt. Es werden pro installierter KI ein Spieler
@@ -74,7 +77,7 @@ if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 </tr></table></center><?php
  } include ("inc.footer.php");
  }
-if ($_GET["fu"]==10) {
+if ($fuid==10) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 ?>
@@ -161,7 +164,7 @@ if ($zahl==2) {
 </tr></table></center><br><br><?php
  } include ("inc.footer.php");
  }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 $file='../daten/gala_strukturen.txt';
@@ -194,7 +197,7 @@ function check() {
       alert("<?php echo $lang['admin']['spiel']['alpha']['min_spieler']?>");
           return false;
   }
-<?php if  ($_POST["startposition"]==1) { ?>
+<?php if (int_post('startposition')==1) { ?>
   if (spielermog[spieleranzahl]==0) {
     alert ('<?php echo str_replace('{1}',$spieleranzahlmog,$lang['admin']['spiel']['alpha']['nur_spieler'])?>');
     return false;
@@ -212,7 +215,7 @@ function check() {
          }
    }
 <?php } ?>
-<?php if ($_POST["siegbedingungen"]==6) {  ?>
+<?php if (int_post('siegbedingungen')==6) {  ?>
 <?php for ($oprt=1;$oprt<=10;$oprt++) { ?>
   if (document.formular.user_<?php echo $oprt; ?>.value >= '1') {
     <?php for ($op=0;$op<=4;$op++) { ?>
@@ -282,7 +285,7 @@ closedir($handle);
    <tr>
    <td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td>
    <td style="color:#aaaaaa;"><?php echo $lang['admin']['spiel']['alpha']['admin']?></td>
-<?php if ($_POST["siegbedingungen"]==6) {  ?>
+<?php if (int_post('siegbedingungen')==6) {  ?>
    <td>&nbsp;&nbsp;</td>
    <td><?php echo $lang['admin']['spiel']['alpha']['teams']?></td>
    <td>&nbsp;</td>
@@ -333,7 +336,7 @@ closedir($handle);
           </select></td>
           <td>&nbsp;</td>
           <td><input type="radio" name="spieler_admin" value="<?php echo $k; ?>"></td>
-<?php if ($_POST["siegbedingungen"]==6) {  ?>
+<?php if (int_post('siegbedingungen')==6) {  ?>
    <td>&nbsp;</td>
    <td>&nbsp;</td>
    <td>&nbsp;</td>
@@ -363,7 +366,7 @@ closedir($handle);
 <?php
  } include ("inc.footer.php");
  }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -416,9 +419,9 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
 include ("inc.header.php");
-if(!empty($_GET["startposset"]) && ($_GET["startposset"] !== '1') and ($_POST["startposition"] == 3)) {
+if ((int_get('startposset') !== 1) and (int_post('startposition') == 3)) {
 ?>
 <script type="text/javascript">
     function check () {
@@ -465,8 +468,8 @@ foreach ($_POST as $key => $value) {
             <?php
               $first = 0;
               for ($n=1;$n<=10;$n++) {
-                if (intval($_POST['user_'.$n]) >= 1) {
-                   $zeiger_temp = @mysql_query("SELECT * FROM $skrupel_user where id = ".intval($_POST['user_'.$n]));
+                if (int_post('user_'.$n) >= 1) {
+                   $zeiger_temp = @mysql_query("SELECT * FROM $skrupel_user where id = ".int_post('user_'.$n));
                    $array_temp = @mysql_fetch_array($zeiger_temp);
                    echo '<tr><td><input type="radio" name="active" id="active" value="'.$n.'" ';
                    if ($first == 0) {
@@ -529,7 +532,7 @@ foreach ($_POST as $key => $value) {
 }
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -590,7 +593,7 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -647,7 +650,7 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -692,7 +695,7 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -745,7 +748,7 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==12) {
+if ($fuid==12) {
 include ("inc.header.php");
 ?>
 <script type="text/javascript">
@@ -818,7 +821,7 @@ for ($n=1;$n<11;$n++) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==11) {
+if ($fuid==11) {
 include ("inc.header.php");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -841,7 +844,7 @@ foreach ($_POST as $key => $value) {
 <?php
 include ("inc.footer.php");
  }
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 srand((double)microtime()*1000000);
@@ -864,7 +867,7 @@ function zufallstring() {
     $salt = "$a$b$c$d$e$f$g$h$i$j$k$l$m$n$o$p$q$r$s$t";
     return $salt;
 }
-*/
+
 define('ONLY_LETTERS',0);
 define('WITH_NUMBERS', 1);
 define('WITH_SPECIAL_CHARACTERS', 2);
@@ -884,7 +887,7 @@ function zufallstring($size = 20, $url = ONLY_LETTERS){
     $salt .= $pool[mt_rand(0, $pool_size - 1)];
   }
   return $salt; 
-} 
+}*/
 //////////////////////////////////////
   $zeiger = @mysql_query("SELECT extend,serial FROM $skrupel_info");
   $array = @mysql_fetch_array($zeiger);
@@ -895,14 +898,14 @@ $sid=zufallstring();
 $spielname=$_POST["spiel_name"];
    $spielname=str_replace("'"," ",$spielname);
    $spielname=str_replace('"'," ",$spielname);
-$ziel_id=$_POST["siegbedingungen"];
-$umfang=$_POST["umfang"];
+$ziel_id=int_post('siegbedingungen');
+$umfang=int_post('umfang');
 $struktur=$_POST["struktur"];
-$piraten_mitte=$_POST["piraten_mitte"];
-$piraten_aussen=$_POST["piraten_aussen"];
-$piraten_min=$_POST["piraten_min"];
-$piraten_max=$_POST["piraten_max"];
-$out=$_POST["out"];
+$piraten_mitte=int_post('piraten_mitte');
+$piraten_aussen=int_post('piraten_aussen');
+$piraten_min=int_post('piraten_min');
+$piraten_max=int_post('piraten_max');
+$out=int_post('out');
 if ($ziel_id==6) {
  $team[1]=$_POST["team1"];
  $team[2]=$_POST["team2"];
@@ -916,13 +919,13 @@ if ($ziel_id==6) {
  $team[10]=$_POST["team10"];
 }
 $module = array();
-$module[0] = @intval($_POST["modul_0"]);
+$module[0] = int_post('modul_0');
 $module[1] = 0;
-$module[2] = @intval($_POST["modul_2"]);
-$module[3] = @intval($_POST["modul_3"]);
-$module[4] = @intval($_POST["modul_4"]);
-$module[5] = @intval($_POST["modul_5"]);
-$module[6] = @intval($_POST["modul_6"]);
+$module[2] = int_post('modul_2');
+$module[3] = int_post('modul_3');
+$module[4] = int_post('modul_4');
+$module[5] = int_post('modul_5');
+$module[6] = int_post('modul_6');
 $module = @implode(":", $module);
 $zeiger = @mysql_query("INSERT INTO $skrupel_spiele (sid,name,module,oput) values ('$sid','$spielname','$module',$out)");
 $zeiger = @mysql_query("SELECT id,sid FROM $skrupel_spiele where sid='$sid'");
@@ -953,7 +956,7 @@ while ($rasse=readdir($handle)) {
 }
 ///////////////////////////////////////////////////SPEZIEN
 $speziena=0;
-if ($_POST["spezien"]>=1) {
+if (int_post('spezien')>=1) {
 $file='../daten/dom_spezien.txt';
 $fp = @fopen("$file","r");
 if ($fp) {
@@ -1010,8 +1013,8 @@ while (!feof ($fp)) {
 ///////////////////////////////////////////////PLANETEN GENRERIEREN ANFANG
 $planetenname=@file('../daten/planetennamen.txt');
 shuffle($planetenname);
-$sternendichte=$_POST["sternendichte"];
-$startposition=$_POST["startposition"];
+$sternendichte=int_post('sternendichte');
+$startposition=int_post('startposition');
 for ($i=0;$i<$sternendichte;$i++) {
 //for ($i=0;$i<50;$i++) {
   $ok=1;
@@ -1056,10 +1059,10 @@ for ($i=0;$i<$sternendichte;$i++) {
   $min1=rand(1,70);
   $min2=rand(1,70);
   $min3=rand(1,70);
-  if ($_POST["mineralien"]==1) { $minrand=1000;$maxrand=7000; }
-  if ($_POST["mineralien"]==2) { $minrand=800;$maxrand=5000; }
-  if ($_POST["mineralien"]==3) { $minrand=500;$maxrand=3500; }
-  if ($_POST["mineralien"]==4) { $minrand=100;$maxrand=1500; }
+  if (int_post('mineralien')==1) { $minrand=1000;$maxrand=7000; }
+  if (int_post('mineralien')==2) { $minrand=800;$maxrand=5000; }
+  if (int_post('mineralien')==3) { $minrand=500;$maxrand=3500; }
+  if (int_post('mineralien')==4) { $minrand=100;$maxrand=1500; }
   $rohstoff=rand($minrand,$maxrand);
   $rohstoffe[0]=rand(0,$rohstoff);
   $rohstoffe[1]=rand(0,($rohstoff-$rohstoffe[0]));
@@ -1074,13 +1077,13 @@ for ($i=0;$i<$sternendichte;$i++) {
   $konz_min1=rand(1,5);
   $konz_min2=rand(1,5);
   $konz_min3=rand(1,5);
-  if ($_POST["leminvorkommen"]==2) {
+  if (int_post('leminvorkommen')==2) {
      $zulemin=(rand(25,50)+100)/100;
      $planet_lemin=round($planet_lemin*$zulemin);
      $zulemin=(rand(25,50)+100)/100;
      $lemin=round($lemin*$zulemin);
   }
-  if ($_POST["leminvorkommen"]==3) {
+  if (int_post('leminvorkommen')==3) {
      $zulemin=(rand(50,100)+100)/100;
      $planet_lemin=round($planet_lemin*$zulemin);
      $zulemin=(rand(50,100)+100)/100;
@@ -1097,9 +1100,9 @@ for ($i=0;$i<$sternendichte;$i++) {
   $native_text='';
   $native_fert='';
   $native_kol=0;
-if ($_POST["spezien"]>=1) {
+if (int_post('spezien')>=1) {
    $zufall=rand(1,100);
-   if ($zufall<=$_POST["spezien"]) {
+   if ($zufall<=int_post('spezien')) {
       $zufall_art=rand(0,$speziena-1);
   $native_id=$ur[$zufall_art][1];
   $native_name=$lang['admin']['spiel']['alpha']['spezien'][$ur[$zufall_art][1]]['name'];
@@ -1119,16 +1122,16 @@ if ($_POST["spezien"]>=1) {
 ///////////////////////////////////////////////PLANETEN GENRERIEREN ENDE
 ////////////////////////////////////////////////WER SPIELT MIT
 $spieleranzahl=0;
-if ($_POST["user_1"]>=1) { $spieleranzahl++;$spieler[1][0]=$_POST["user_1"];$spieler[1][1]=$_POST["rasse_1"]; } else { $spieler[1][0]=0;$spieler[1][1]=''; }
-if ($_POST["user_2"]>=1) { $spieleranzahl++;$spieler[2][0]=$_POST["user_2"];$spieler[2][1]=$_POST["rasse_2"]; } else { $spieler[2][0]=0;$spieler[2][1]=''; }
-if ($_POST["user_3"]>=1) { $spieleranzahl++;$spieler[3][0]=$_POST["user_3"];$spieler[3][1]=$_POST["rasse_3"]; } else { $spieler[3][0]=0;$spieler[3][1]=''; }
-if ($_POST["user_4"]>=1) { $spieleranzahl++;$spieler[4][0]=$_POST["user_4"];$spieler[4][1]=$_POST["rasse_4"]; } else { $spieler[4][0]=0;$spieler[4][1]=''; }
-if ($_POST["user_5"]>=1) { $spieleranzahl++;$spieler[5][0]=$_POST["user_5"];$spieler[5][1]=$_POST["rasse_5"]; } else { $spieler[5][0]=0;$spieler[5][1]=''; }
-if ($_POST["user_6"]>=1) { $spieleranzahl++;$spieler[6][0]=$_POST["user_6"];$spieler[6][1]=$_POST["rasse_6"]; } else { $spieler[6][0]=0;$spieler[6][1]=''; }
-if ($_POST["user_7"]>=1) { $spieleranzahl++;$spieler[7][0]=$_POST["user_7"];$spieler[7][1]=$_POST["rasse_7"]; } else { $spieler[7][0]=0;$spieler[7][1]=''; }
-if ($_POST["user_8"]>=1) { $spieleranzahl++;$spieler[8][0]=$_POST["user_8"];$spieler[8][1]=$_POST["rasse_8"]; } else { $spieler[8][0]=0;$spieler[8][1]=''; }
-if ($_POST["user_9"]>=1) { $spieleranzahl++;$spieler[9][0]=$_POST["user_9"];$spieler[9][1]=$_POST["rasse_9"]; } else { $spieler[9][0]=0;$spieler[9][1]=''; }
-if ($_POST["user_10"]>=1) { $spieleranzahl++;$spieler[10][0]=$_POST["user_10"];$spieler[10][1]=$_POST["rasse_10"]; } else { $spieler[10][0]=0;$spieler[10][1]=''; }
+if (int_post('user_1')>=1) { $spieleranzahl++;$spieler[1][0]=int_post('user_1');$spieler[1][1]=$_POST["rasse_1"]; } else { $spieler[1][0]=0;$spieler[1][1]=''; }
+if (int_post('user_2')>=1) { $spieleranzahl++;$spieler[2][0]=int_post('user_2');$spieler[2][1]=$_POST["rasse_2"]; } else { $spieler[2][0]=0;$spieler[2][1]=''; }
+if (int_post('user_3')>=1) { $spieleranzahl++;$spieler[3][0]=int_post('user_3');$spieler[3][1]=$_POST["rasse_3"]; } else { $spieler[3][0]=0;$spieler[3][1]=''; }
+if (int_post('user_4')>=1) { $spieleranzahl++;$spieler[4][0]=int_post('user_4');$spieler[4][1]=$_POST["rasse_4"]; } else { $spieler[4][0]=0;$spieler[4][1]=''; }
+if (int_post('user_5')>=1) { $spieleranzahl++;$spieler[5][0]=int_post('user_5');$spieler[5][1]=$_POST["rasse_5"]; } else { $spieler[5][0]=0;$spieler[5][1]=''; }
+if (int_post('user_6')>=1) { $spieleranzahl++;$spieler[6][0]=int_post('user_6');$spieler[6][1]=$_POST["rasse_6"]; } else { $spieler[6][0]=0;$spieler[6][1]=''; }
+if (int_post('user_7')>=1) { $spieleranzahl++;$spieler[7][0]=int_post('user_7');$spieler[7][1]=$_POST["rasse_7"]; } else { $spieler[7][0]=0;$spieler[7][1]=''; }
+if (int_post('user_8')>=1) { $spieleranzahl++;$spieler[8][0]=int_post('user_8');$spieler[8][1]=$_POST["rasse_8"]; } else { $spieler[8][0]=0;$spieler[8][1]=''; }
+if (int_post('user_9')>=1) { $spieleranzahl++;$spieler[9][0]=int_post('user_9');$spieler[9][1]=$_POST["rasse_9"]; } else { $spieler[9][0]=0;$spieler[9][1]=''; }
+if (int_post('user_10')>=1) { $spieleranzahl++;$spieler[10][0]=int_post('user_10');$spieler[10][1]=$_POST["rasse_10"]; } else { $spieler[10][0]=0;$spieler[10][1]=''; }
 ///////////////////////////////////////////////SPIELER AUFBAUEN ANFANG
 ///////////////////////////////////////////////STARTPOSITIONEN
 if ($startposition==1) {
@@ -1168,12 +1171,13 @@ if ($startposition==2) {
 }
 if (3 == $startposition) {
     for ($kkk=1;$kkk<11;$kkk++) {
-        $position[$kkk]['x'] = $_POST['user_'.$kkk.'_x'];
-        $position[$kkk]['y'] = $_POST['user_'.$kkk.'_y'];
+        $position[$kkk]['x'] = int_post('user_'.$kkk.'_x');
+        $position[$kkk]['y'] = int_post('user_'.$kkk.'_y');
     }
 }
-if (($_POST["imperiumgroesse"]==1) or ($_POST["imperiumgroesse"]==2) or ($_POST["imperiumgroesse"]==3) or ($_POST["imperiumgroesse"]==4)) {
-if ($_POST["imperiumgroesse"]==1) {
+$imperiumgroesse = int_post('imperiumgroesse');
+if (($imperiumgroesse==1) or ($imperiumgroesse==2) or ($imperiumgroesse==3) or ($imperiumgroesse==4)) {
+if ($imperiumgroesse==1) {
 }
 $iii=0;
 for ($i=1;$i<=10;$i++) {
@@ -1207,15 +1211,15 @@ for ($i=1;$i<=10;$i++) {
   $minen=5;
   $abwehr=5;
   $fabriken=5;
-  $cantox=$_POST["geldmittel"];
+  $cantox=int_post('geldmittel');
   $lemin=rand(50,70);
   $min1=rand(50,70);
   $min2=rand(50,70);
   $min3=rand(50,70);
-  if ($_POST["mineralienhome"]==1) { $minrand=2000;$maxrand=3000; }
-  if ($_POST["mineralienhome"]==2) { $minrand=1500;$maxrand=2500; }
-  if ($_POST["mineralienhome"]==3) { $minrand=1000;$maxrand=2000; }
-  if ($_POST["mineralienhome"]==4) { $minrand=500;$maxrand=1000; }
+  if (int_post('mineralienhome')==1) { $minrand=2000;$maxrand=3000; }
+  if (int_post('mineralienhome')==2) { $minrand=1500;$maxrand=2500; }
+  if (int_post('mineralienhome')==3) { $minrand=1000;$maxrand=2000; }
+  if (int_post('mineralienhome')==4) { $minrand=500;$maxrand=1000; }
   $planet_lemin=rand($minrand,$maxrand);
   $planet_min1=rand($minrand,$maxrand);
   $planet_min2=rand($minrand,$maxrand);
@@ -1244,7 +1248,7 @@ for ($i=1;$i<=10;$i++) {
   if ($klasse==9) { $temp=rand(25,45); }
   }
     $zeiger = @mysql_query("UPDATE $skrupel_planeten set konz_lemin=$konz_lemin,konz_min1=$konz_min1,konz_min2=$konz_min2,konz_min3=$konz_min3,osys_anzahl=4,native_id=0,native_name ='',native_art=0,native_art_name='',native_abgabe=0,native_bild='',native_text='',native_fert='',native_kol=0,besitzer=$i,heimatplanet=$i,vorrat=$vorrat,cantox=$cantox,minen=$minen,abwehr=$abwehr,fabriken=$fabriken,kolonisten=$kolonisten,lemin=$lemin,min1=$min1,min2=$min2,min3=$min3,klasse=$klasse,bild=$bild,temp=$temp,planet_lemin=$planet_lemin,planet_min1=$planet_min1,planet_min2=$planet_min2,planet_min3=$planet_min3 where id=$pid");
-if (($_POST["imperiumgroesse"]==1) or ($_POST["imperiumgroesse"]==2)) {
+if (($imperiumgroesse==1) or ($imperiumgroesse==2)) {
   $namesb='Starbase I';
   $rasse = $spieler[$i][1];
   $zeiger = @mysql_query("INSERT INTO $skrupel_sternenbasen (name,x_pos,y_pos,rasse,planetid,besitzer,status,spiel) values ('$namesb',$x_pos,$y_pos,'$rasse',$pid,$i,1,$spiel)");
@@ -1253,7 +1257,7 @@ if (($_POST["imperiumgroesse"]==1) or ($_POST["imperiumgroesse"]==2)) {
   $baid=$array_temp["id"];
   $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set sternenbasis=2,sternenbasis_name='$namesb',sternenbasis_id=$baid,sternenbasis_rasse='$rasse' where id=$pid");
 }
-if ($_POST["imperiumgroesse"]==1) {
+if ($imperiumgroesse==1) {
     $schiffbau_klasse=$array["schiffbau_klasse"];
     $schiffbau_bild_gross=$array["schiffbau_bild_gross"];
     $schiffbau_bild_klein=$array["schiffbau_bild_klein"];
@@ -1282,8 +1286,8 @@ if ($_POST["imperiumgroesse"]==1) {
 }
 //////////////////////////////////////////////SPIELER AUFBAUEN ENDE
 ///////////////////////////////////////////////INSTABLIE WURMLOECHER ANFANG
-if ($_POST["instabil"]>=1) {
-for ($i=0;$i<$_POST["instabil"];$i++) {
+if (int_post('instabil')>=1) {
+for ($i=0;$i<int_post('instabil');$i++) {
   $ok=1;
   while ($ok==1) {
   $x=rand(50,$umfang-100);
@@ -1309,30 +1313,31 @@ for ($i=0;$i<$_POST["instabil"];$i++) {
 }
 ///////////////////////////////////////////////INSTABLIE WURMLOECHER ENDE
 ///////////////////////////////////////////////STABILE WURMLOECHER ANFANG
-if ($_POST["stabil"]>=1) {
-  if ($_POST["stabil"]<=5) {$anzahl=$_POST["stabil"];}
-  if ($_POST["stabil"]==6) {$anzahl=1;}
-  if ($_POST["stabil"]==7) {$anzahl=2;}
-  if ($_POST["stabil"]==8) {$anzahl=1;}
-  if ($_POST["stabil"]==9) {$anzahl=2;}
-  if ($_POST["stabil"]==10) {$anzahl=2;}
-  if ($_POST["stabil"]==11) {$anzahl=1;}
-  if ($_POST["stabil"]==12) {$anzahl=1;}
-  if ($_POST["stabil"]==13) {$anzahl=2;}
+$stabil = int_post('stabil');
+if ($stabil>=1) {
+  if ($stabil<=5) {$anzahl=$stabil;}
+  if ($stabil==6) {$anzahl=1;}
+  if ($stabil==7) {$anzahl=2;}
+  if ($stabil==8) {$anzahl=1;}
+  if ($stabil==9) {$anzahl=2;}
+  if ($stabil==10) {$anzahl=2;}
+  if ($stabil==11) {$anzahl=1;}
+  if ($stabil==12) {$anzahl=1;}
+  if ($stabil==13) {$anzahl=2;}
    for ($i=0;$i<$anzahl;$i++) {
   $ok=1;
   while ($ok==1) {
-  if ($_POST["stabil"]<=5) { $x=rand(50,$umfang-100);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==6) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
-  if ($_POST["stabil"]==7) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
-  if ($_POST["stabil"]==8) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==9) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
-  if (($_POST["stabil"]==10) and ($i==0)) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
-  if (($_POST["stabil"]==10) and ($i==1)) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==11) { $x=rand(50,($umfang/2)-50);$y=rand(50,($umfang/2)-50); }
-  if ($_POST["stabil"]==12) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,($umfang/2)-50); }
-  if (($_POST["stabil"]==13) and ($i==0)) { $x=rand(50,($umfang/2)-50);$y=rand(50,($umfang/2)-50); }
-  if (($_POST["stabil"]==13) and ($i==1)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,($umfang/2)-50); }
+  if ($stabil<=5) { $x=rand(50,$umfang-100);$y=rand(50,$umfang-100); }
+  if ($stabil==6) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
+  if ($stabil==7) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
+  if ($stabil==8) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
+  if ($stabil==9) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
+  if (($stabil==10) and ($i==0)) { $x=rand(50,$umfang-100);$y=rand(50,($umfang/2)-50); }
+  if (($stabil==10) and ($i==1)) { $x=rand(50,($umfang/2)-50);$y=rand(50,$umfang-100); }
+  if ($stabil==11) { $x=rand(50,($umfang/2)-50);$y=rand(50,($umfang/2)-50); }
+  if ($stabil==12) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,($umfang/2)-50); }
+  if (($stabil==13) and ($i==0)) { $x=rand(50,($umfang/2)-50);$y=rand(50,($umfang/2)-50); }
+  if (($stabil==13) and ($i==1)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,($umfang/2)-50); }
   $oben=$y-30;
   $unten=$y+30;
   $links=$x-30;
@@ -1357,17 +1362,17 @@ if ($_POST["stabil"]>=1) {
       $y_pos_eins=$array["y_pos"];
   $ok=1;
   while ($ok==1) {
-  if ($_POST["stabil"]<=5) { $x=rand(50,$umfang-100);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==6) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
-  if ($_POST["stabil"]==7) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
-  if ($_POST["stabil"]==8) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==9) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
-  if (($_POST["stabil"]==10) and ($i==0)) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
-  if (($_POST["stabil"]==10) and ($i==1)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
-  if ($_POST["stabil"]==11) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
-  if ($_POST["stabil"]==12) { $x=rand(50,($umfang/2)-50);$y=rand(($umfang/2)+50,$umfang-100); }
-  if (($_POST["stabil"]==13) and ($i==0)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
-  if (($_POST["stabil"]==13) and ($i==1)) { $x=rand(50,($umfang/2)-50);$y=rand(($umfang/2)+50,$umfang-100); }
+  if ($stabil<=5) { $x=rand(50,$umfang-100);$y=rand(50,$umfang-100); }
+  if ($stabil==6) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
+  if ($stabil==7) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
+  if ($stabil==8) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
+  if ($stabil==9) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
+  if (($stabil==10) and ($i==0)) { $x=rand(50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
+  if (($stabil==10) and ($i==1)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(50,$umfang-100); }
+  if ($stabil==11) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
+  if ($stabil==12) { $x=rand(50,($umfang/2)-50);$y=rand(($umfang/2)+50,$umfang-100); }
+  if (($stabil==13) and ($i==0)) { $x=rand(($umfang/2)+50,$umfang-100);$y=rand(($umfang/2)+50,$umfang-100); }
+  if (($stabil==13) and ($i==1)) { $x=rand(50,($umfang/2)-50);$y=rand(($umfang/2)+50,$umfang-100); }
   $oben=$y-30;
   $unten=$y+30;
   $links=$x-30;
@@ -1508,7 +1513,7 @@ if ($ziel_id==5) {
 }
 //////////////////////////////////////////////ZIEL
 ///////////////////////////////////////////////NEBEL ERSTELLEN ANFANG
-$nebel=$_POST["nebel"];
+$nebel=int_post('nebel');
       $besitzer_recht[1]='1000000000';
       $besitzer_recht[2]='0100000000';
       $besitzer_recht[3]='0010000000';
@@ -1553,10 +1558,10 @@ $spieler_7=$spieler[7][0];
 $spieler_8=$spieler[8][0];
 $spieler_9=$spieler[9][0];
 $spieler_10=$spieler[10][0];
-$plasma_wahr=$_POST["wahr"];
-$plasma_lang=$_POST["lang"];
-$plasma_max=$_POST["max"];
-$spieler_admin=$_POST["spieler_admin"];
+$plasma_wahr=int_post('wahr');
+$plasma_lang=int_post('lang');
+$plasma_max=int_post('max');
+$spieler_admin=int_post('spieler_admin');
 for ($sp=1; $sp<=10; $sp++) {
     if (strlen($spieler_rasse_c[$sp])>=2) {
         $spieler_rassename_c[$sp] = $namerassen[$spieler_rasse_c[$sp]];

--- a/admin/spiel_beta.php
+++ b/admin/spiel_beta.php
@@ -1,8 +1,11 @@
 <?php
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.admin.spiel_beta.php");
+$fuid = int_get('fu');
 $prozentarray=array(0,1,2,3,4,5,6,7,8,9,10,15,20,30,40,50,60,70,80,90,100);
-if ($_GET["fu"]==1) {
+
+if ($fuid==1) {
   include_once ('../inhalt/inc.hilfsfunktionen.php');
   include ("inc.header.php");
   if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
@@ -228,11 +231,10 @@ while ($rasses=readdir($handle)){
 <?php
 } include ("inc.footer.php");
  }
- if ($_GET["fu"]==2) {
-include ("../inc.conf.php");
+ if ($fuid==2) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-$spiel=$_GET["slot_id"];
+$spiel=int_get('slot_id');
     $zeiger2 = @mysql_query("SELECT * FROM $skrupel_spiele where id='$spiel'");
     $datensaetze2 = @mysql_num_rows($zeiger2);
     $array2 = @mysql_fetch_array($zeiger2);
@@ -497,42 +499,41 @@ if ($spieler_id_c[$k]>=1) {
 }
 include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
-  include ("../inc.conf.php");
+if ($fuid==3) {
   include ("inc.header.php");
   if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-  $spiel=$_GET["slot_id"];
+  $spiel=int_get('slot_id');
   $spiel_name=$_POST["spiel_name"];
   $module = array();
-  $module[0] = @intval($_POST["modul_0"]);
+  $module[0] = int_post('modul_0');
   $module[1] = 0;
-  $module[2] = @intval($_POST["modul_2"]);
-  $module[3] = @intval($_POST["modul_3"]);
-    $module[4] = @intval($_POST["modul_4"]);
-    $module[5] = @intval($_POST["modul_5"]);
-    $module[6] = @intval($_POST["modul_6"]);  
+  $module[2] = int_post('modul_2');
+  $module[3] = int_post('modul_3');
+    $module[4] = int_post('modul_4');
+    $module[5] = int_post('modul_5');
+    $module[6] = int_post('modul_6');  
   $module = @implode(":", $module);
-  $aufloesung=intval($_POST["aufloesung"]);
-  $autotick=intval($_POST["autotick"]);
-  $out=intval($_POST["out"]);
-  $max=intval($_POST["max"]);
-  $wahr=intval($_POST["wahr"]);
-  $llang=intval($_POST["llang"]);
-  $nebel=intval($_POST["nebel"]);
-  $piraten_mitte=intval($_POST["piraten_mitte"]);
-  $piraten_aussen=intval($_POST["piraten_aussen"]);
-  $piraten_min=intval($_POST["piraten_min"]);
-  $piraten_max=intval($_POST["piraten_max"]);
-  $spieler_raus[1]=intval($_POST["spieler_1_raus"]);
-  $spieler_raus[2]=intval($_POST["spieler_2_raus"]);
-  $spieler_raus[3]=intval($_POST["spieler_3_raus"]);
-  $spieler_raus[4]=intval($_POST["spieler_4_raus"]);
-  $spieler_raus[5]=intval($_POST["spieler_5_raus"]);
-  $spieler_raus[6]=intval($_POST["spieler_6_raus"]);
-  $spieler_raus[7]=intval($_POST["spieler_7_raus"]);
-  $spieler_raus[8]=intval($_POST["spieler_8_raus"]);
-  $spieler_raus[9]=intval($_POST["spieler_9_raus"]);
-  $spieler_raus[10]=intval($_POST["spieler_10_raus"]);
+  $aufloesung=int_post('aufloesung');
+  $autotick=int_post('autotick');
+  $out=int_post('out');
+  $max=int_post('max');
+  $wahr=int_post('wahr');
+  $llang=int_post('llang');
+  $nebel=int_post('nebel');
+  $piraten_mitte=int_post('piraten_mitte');
+  $piraten_aussen=int_post('piraten_aussen');
+  $piraten_min=int_post('piraten_min');
+  $piraten_max=int_post('piraten_max');
+  $spieler_raus[1]=int_post('spieler_1_raus');
+  $spieler_raus[2]=int_post('spieler_2_raus');
+  $spieler_raus[3]=int_post('spieler_3_raus');
+  $spieler_raus[4]=int_post('spieler_4_raus');
+  $spieler_raus[5]=int_post('spieler_5_raus');
+  $spieler_raus[6]=int_post('spieler_6_raus');
+  $spieler_raus[7]=int_post('spieler_7_raus');
+  $spieler_raus[8]=int_post('spieler_8_raus');
+  $spieler_raus[9]=int_post('spieler_9_raus');
+  $spieler_raus[10]=int_post('spieler_10_raus');
   $zeiger = @mysql_query("SELECT spiel,partei_a,partei_b,status,optionen FROM $skrupel_politik where spiel=$spiel");
   $polanzahl = @mysql_num_rows($zeiger);
   if ($polanzahl>=1) {
@@ -623,11 +624,10 @@ if ($_GET["fu"]==3) {
   } 
   include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
-include ("../inc.conf.php");
+if ($fuid==4) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-$spiel=$_GET["slot_id"];
+$spiel=int_get('slot_id');
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
 <center><table border="0" height="100%" cellspacing="0" cellpadding="0">
@@ -641,11 +641,10 @@ $spiel=$_GET["slot_id"];
 <?php
 } include ("inc.footer.php");
  }
-if ($_GET["fu"]==5) {
-include ("../inc.conf.php");
+if ($fuid==5) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-$spiel=$_GET["slot_id"];
+$spiel=int_get('slot_id');
     $zeiger2 = @mysql_query("SELECT * FROM $skrupel_spiele where id='$spiel'");
     $datensaetze2 = @mysql_num_rows($zeiger2);
     if ($datensaetze2==1) {

--- a/admin/spiel_gamma.php
+++ b/admin/spiel_gamma.php
@@ -3,8 +3,11 @@
 :noTabs=false:indentSize=4:tabSize=4:folding=explicit:collapseFolds=1:
 */
 include ("../inc.conf.php");
+include_once ('../inhalt/inc.hilfsfunktionen.php');
 include ("../lang/".$language."/lang.spiel_gamma.php");
-if ($_GET["fu"]==1) {
+$fuid = int_get('fu');
+
+if ($fuid==1) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 ?>
@@ -109,11 +112,10 @@ if ($spielanzahl>=1) {
 }
 include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
-include ("../inc.conf.php");
+if ($fuid==2) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-    $spiel = $_GET["slot_id"];
+    $spiel = int_get('slot_id');
     if (@intval(substr($spiel_extend,1,1))==1){
       include("../extend/ki/ki_basis/spielLoeschenKI.php");
     }

--- a/admin/welcome.php
+++ b/admin/welcome.php
@@ -1,7 +1,10 @@
 <?php
-if ($_GET["fu"]==1) {
-  include ("../inc.conf.php");
-  include ("../lang/".$language."/lang.admin.welcome.php");
+include ('../inc.conf.php');
+include_once ('../inhalt/inc.hilfsfunktionen.php');
+include ("../lang/".$language."/lang.admin.welcome.php");
+$fuid = int_get('fu');
+
+if ($fuid==1) {
   include ("inc.header.php");
   if(($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)){
     ?>

--- a/inhalt/admin.php
+++ b/inhalt/admin.php
@@ -1,9 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='admin';
+include ('../inc.conf.php');
 include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'admin';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
   include ("inc.header.php");
   if ($spieler==$spieler_admin) {
     ?>
@@ -153,7 +154,7 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
   }
 }
-if($_GET["fu"]==2){
+if ($fuid==2) {
   include ("inc.header.php");
   if($spieler==$spieler_admin){
     $main_verzeichnis="../";
@@ -190,7 +191,7 @@ if($_GET["fu"]==2){
     include ("inc.footer.php");
   }
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
   include ("inc.header.php");
   if($spieler==$spieler_admin){
     if ($spieleranzahl==10) {
@@ -361,14 +362,14 @@ if ($_GET["fu"]==3) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $uid = $_POST["spielerid"];
+        $uid = int_post('spielerid');
         if (($uid>1) and ($spieler_1<>$uid) and ($spieler_2<>$uid) and ($spieler_3<>$uid) and ($spieler_4<>$uid) and ($spieler_5<>$uid) and ($spieler_6<>$uid) and ($spieler_7<>$uid) and ($spieler_8<>$uid) and ($spieler_9<>$uid) and ($spieler_10<>$uid)) {
             $kord=explode("-",$_POST["koord"]);
-            $i=$_POST["slot"];
-            $ausstattung=$_POST["ausstattung"];
+            $i=int_post('slot');
+            $ausstattung=int_post('ausstattung');
             $rasse=$_POST["rasse"];
 ///////////////////////////////////////////////////////////////////////////////////////////////RASSENEIGENSCHAFTEN ANFANG
             $daten_verzeichnis="../daten/";
@@ -413,16 +414,17 @@ if ($_GET["fu"]==4) {
             $minen=5;
             $abwehr=5;
             $fabriken=5;
-            $cantox=$_POST["geldmittel"];
-            if ($_POST["mineralienhome"]==1) { 
+            $cantox=int_post('geldmittel');
+            $mineralienhome=int_post('mineralienhome');
+            if ($mineralienhome==1) {
                 $minrand=50;$maxrand=70;
-            }elseif ($_POST["mineralienhome"]==2) {
-                $minrand=150;$maxrand=250; 
-            }elseif ($_POST["mineralienhome"]==3) {
-                $minrand=400;$maxrand=600; 
-            }elseif ($_POST["mineralienhome"]==4) { 
-                $minrand=700;$maxrand=1000; 
-            }elseif ($_POST["mineralienhome"]==5) {
+            }elseif ($mineralienhome==2) {
+                $minrand=150;$maxrand=250;
+            }elseif ($mineralienhome==3) {
+                $minrand=400;$maxrand=600;
+            }elseif (mineralienhome==4) {
+                $minrand=700;$maxrand=1000;
+            }elseif (mineralienhome==5) {
                 $minrand=1500;$maxrand=2000;
             }
             $lemin=rand($minrand,$maxrand);
@@ -480,7 +482,7 @@ if ($_GET["fu"]==4) {
             $spalte_spieler_rassenname="spieler_".$i."_rassename";
             $planetenwert=5;
             if ($ausstattung>=2) { $basenwert=10; } else { $basenwert=0; }
-            $spielerid = $_POST["spielerid"];
+            $spielerid = int_post('spielerid');
             $zeiger_temp = @mysql_query("UPDATE $skrupel_spiele set $spalte_spieler=$spielerid,$spalte_spieler_rasse='$rasse',$spalte_spieler_planeten=$planetenwert,$spalte_spieler_basen=$basenwert,$spalte_spieler_schiffe=0,$spalte_spieler_rassenname='$rassenname',spieleranzahl=spieleranzahl+1 where id=$spiel");
             function allifinden($partei_a,$partei_b) {
                 global $conn,$db,$skrupel_politik,$spiel;
@@ -521,7 +523,7 @@ if ($_GET["fu"]==4) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         ?>
@@ -656,10 +658,10 @@ if ($_GET["fu"]==5) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $raus=$_POST["spielerid"];
+        $raus=int_post('spielerid');
         $zeiger = @mysql_query("SELECT besitzer,id,spiel FROM $skrupel_sternenbasen where besitzer=$raus and spiel=$spiel order by id");
         $basenanzahl = @mysql_num_rows($zeiger);
         if ($basenanzahl>=1) {
@@ -704,7 +706,7 @@ if ($_GET["fu"]==6) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         $zeiger_temp = @mysql_query("SELECT id,autozug FROM $skrupel_spiele where id=$spiel");
@@ -759,10 +761,10 @@ if ($_GET["fu"]==7) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $autozug=$_POST["autozug"];
+        $autozug=int_post('autozug');
         $zeiger_temp = @mysql_query("UPDATE $skrupel_spiele set autozug=$autozug where id=$spiel");
         ?>
         <body text="#ffffff" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#ffffff" vlink="#ffffff" alink="#ffffff" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -775,7 +777,7 @@ if ($_GET["fu"]==8) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         ?>
@@ -876,12 +878,12 @@ if ($_GET["fu"]==9) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==10) {
+if ($fuid==10) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $plasma_max=$_POST["max"];
-        $plasma_wahr=$_POST["wahr"];
-        $plasma_lang=$_POST["lang"];
+        $plasma_max=int_post('max');
+        $plasma_wahr=int_post('wahr');
+        $plasma_lang=int_post('lang');
         $zeiger_temp = @mysql_query("UPDATE $skrupel_spiele set plasma_max=$plasma_max,plasma_wahr=$plasma_wahr,plasma_lang=$plasma_lang where id=$spiel");
         ?>
         <body text="#ffffff" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#444444" link="#ffffff" vlink="#ffffff" alink="#ffffff" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -894,7 +896,7 @@ if ($_GET["fu"]==10) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==11) {
+if ($fuid==11) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         ?>
@@ -915,7 +917,7 @@ if ($_GET["fu"]==11) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==12) {
+if ($fuid==12) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         ?>
@@ -1097,13 +1099,13 @@ if ($_GET["fu"]==12) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==13) {
+if ($fuid==13) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $piraten_aussen2=$_POST["piraten_aussen"];
-        $piraten_mitte2=$_POST["piraten_mitte"];
-        $piraten_max2=$_POST["piraten_max"];
-        $piraten_min2=$_POST["piraten_min"];
+        $piraten_aussen2=int_post('piraten_aussen');
+        $piraten_mitte2=int_post('piraten_mitte');
+        $piraten_max2=int_post('piraten_max');
+        $piraten_min2=int_post('piraten_min');
         $zeiger_temp = @mysql_query("UPDATE $skrupel_spiele set piraten_mitte=$piraten_mitte2,piraten_aussen=$piraten_aussen2,piraten_max=$piraten_max2,piraten_min=$piraten_min2 where id=$spiel");
         ?>
         <body text="#ffffff" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#444444" link="#ffffff" vlink="#ffffff" alink="#ffffff" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -1116,7 +1118,7 @@ if ($_GET["fu"]==13) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==14) {
+if ($fuid==14) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
         $checked[0] = "";
@@ -1166,16 +1168,16 @@ if ($_GET["fu"]==14) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==15) {
+if ($fuid==15) {
     include ("inc.header.php");
     if ($spieler==$spieler_admin) {
-        $module[0] = @intval($_POST['modul_0']);
+        $module[0] = int_post('modul_0');
         $module[1] = 0;
-        $module[2] = @intval($_POST['modul_2']);
-        $module[3] = @intval($_POST['modul_3']);
-        $module[4] = @intval($_POST['modul_4']);
-        $module[5] = @intval($_POST['modul_5']);
-        $module[6] = @intval($_POST['modul_6']);        
+        $module[2] = int_post('modul_2');
+        $module[3] = int_post('modul_3');
+        $module[4] = int_post('modul_4');
+        $module[5] = int_post('modul_5');
+        $module[6] = int_post('modul_6');
         $module_neu = @implode(":", $module);
         @mysql_query("UPDATE $skrupel_spiele SET module='$module_neu' WHERE id=$spiel");
         ?>

--- a/inhalt/aufbau.php
+++ b/inhalt/aufbau.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
+include ('../inc.conf.php');
+include_once ('../inhalt/inc.hilfsfunktionen.php');
+$fuid = int_get('fu');
 if(empty($_GET["bildpfad"])) {$_GET["bildpfad"]='../bilder';}
 
-if ($_GET["fu"]==0) { ?>
+if ($fuid==0) { ?>
     <html>
         <head>
             <META NAME="Author" CONTENT="Bernd Kantoks bernd@kantoks.de">
@@ -11,8 +13,8 @@ if ($_GET["fu"]==0) { ?>
         </body>
     </html>
 <?php }
-if (($_GET["fu"]>=1) and ($_GET["fu"]<=99)) {
-    if ($_GET["fu"]==8) {
+if (($fuid>=1) and ($fuid<=99)) {
+    if ($fuid==8) {
         $url="http://".$_SERVER['SERVER_NAME'];
         $folders = explode('/', $_SERVER['SCRIPT_NAME']);
         $count = 0;
@@ -36,12 +38,12 @@ if (($_GET["fu"]>=1) and ($_GET["fu"]<=99)) {
             <head>
                 <META NAME="Author" CONTENT="Bernd Kantoks bernd@kantoks.de">
             </head>
-            <body text="#000000" bgcolor="#444444" background="<?php echo $_GET["bildpfad"]; ?>/aufbau/<?php echo $_GET["fu"]; ?>.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+            <body text="#000000" bgcolor="#444444" background="<?php echo $_GET["bildpfad"]; ?>/aufbau/<?php echo $fuid; ?>.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
             </body>
         </html>
     <?php } ?>
 <?php }
-if ($_GET["fu"]==100) {
+if ($fuid==100) {
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="50,18,*,16,50">

--- a/inhalt/basen.php
+++ b/inhalt/basen.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='basen';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'basen';
+$fuid = int_get('fu');
+$baid = int_get('baid');
 
-$baid=$_GET["baid"];
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>
@@ -146,7 +148,7 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" cols="*,26,290,167,420,26,*">
@@ -168,7 +170,7 @@ if ($_GET["fu"]==2) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
@@ -403,7 +405,7 @@ if ($_GET["fu"]==3) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
@@ -453,7 +455,7 @@ if ($_GET["fu"]==4) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>
@@ -477,7 +479,7 @@ if ($_GET["fu"]==5) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
@@ -541,9 +543,9 @@ if ($_GET["fu"]==6) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
-    $pid=$_GET["pid"];
+    $pid=int_get('pid');
     ?>
     <script language=JavaScript>
         function linksub(url) {
@@ -579,9 +581,9 @@ if ($_GET["fu"]==7) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
-    $pid=$_GET["pid"];
+    $pid=int_get('pid');
     ?>
     <script language=JavaScript>
         function linksub(url) {

--- a/inhalt/basen_alpha.php
+++ b/inhalt/basen_alpha.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='basen_alpha';
-$baid=$_GET["baid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'basen_alpha';
+$fuid = int_get('fu');
+$baid = int_get('baid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $kosten_huelle = array ("0","100","300","600","1400","2400","3600","6100","11100","18600","28600");
@@ -202,14 +204,14 @@ if ($_GET["fu"]==1) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $kosten_huelle = array ("0","100","300","600","1400","2400","3600","6100","11100","18600","28600");
     $kosten_antrieb = array ("0","100","300","600","1000","1500","2100","2800","6800","13800","23800");
     $kosten_energetik = array ("0","100","500","1400","3000","5500","9100","14000","20400","28500","38500");
     $kosten_explosiv = array ("0","100","500","1400","3000","5500","9100","14000","20400","28500","38500");
-    $abwehrauftrag=$_POST["explosivtl"];
+    $abwehrauftrag=int_post('explosivtl');
     $array = @mysql_fetch_array($zeiger);
     $baid=$array["id"];
     $name=$array["name"];
@@ -233,7 +235,7 @@ if ($_GET["fu"]==2) {
         $cantox=$array["cantox"];
         $schalter=0;
         if($t_huelle<10){
-            for($li=$t_huelle+1;$li<=$_POST["huelletl"];$li++){
+            for($li=$t_huelle+1;$li<=int_post('huelletl');$li++){
                 if ($cantox>=$kosten_huelle[$li]-$kosten_huelle[$li-1]) {
                     $minus=$kosten_huelle[$li]-$kosten_huelle[$li-1];
                     $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=cantox-$minus where besitzer=$spieler and id=$planetid");
@@ -249,7 +251,7 @@ if ($_GET["fu"]==2) {
             $message=$lang['basenalpha']['rumpferhoeht']."<br><br>";
         }
         if($t_antrieb<10){
-            for($li=$t_antrieb+1;$li<=$_POST["antriebtl"];$li++){
+            for($li=$t_antrieb+1;$li<=int_post('antriebtl');$li++){
                 if ($cantox>=$kosten_antrieb[$li]-$kosten_antrieb[$li-1]) {
                     $minus=$kosten_antrieb[$li]-$kosten_antrieb[$li-1];
                     $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=cantox-$minus where besitzer=$spieler and id=$planetid");
@@ -265,7 +267,7 @@ if ($_GET["fu"]==2) {
             $message=$message.$lang['basenalpha']['antrieberhoeht']."<br><br>";
         }
         if($t_energie<10){
-            for($li=$t_energie+1;$li<=$_POST["energietl"];$li++){
+            for($li=$t_energie+1;$li<=int_post('energietl');$li++){
                 if ($cantox>=$kosten_energetik[$li]-$kosten_energetik[$li-1]) {
                     $minus=$kosten_energetik[$li]-$kosten_energetik[$li-1];
                     $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=cantox-$minus where besitzer=$spieler and id=$planetid");
@@ -281,7 +283,7 @@ if ($_GET["fu"]==2) {
             $message=$message.$lang['basenalpha']['energetikerhoeht']."<br><br>";
         }
         if($t_explosiv<10){
-            for($li=$t_explosiv+1;$li<=$_POST["explosivtl"];$li++){
+            for($li=$t_explosiv+1;$li<=int_post('explosivtl');$li++){
                 if ($cantox>=$kosten_explosiv[$li]-$kosten_explosiv[$li-1]) {
                     $minus=$kosten_explosiv[$li]-$kosten_explosiv[$li-1];
                     $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=cantox-$minus where besitzer=$spieler and id=$planetid");
@@ -316,7 +318,7 @@ if ($_GET["fu"]==2) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");    
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -416,9 +418,9 @@ if ($_GET["fu"]==3) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
-    $abwehrauftrag=$_POST["abwehrauftrag"];
+    $abwehrauftrag=int_post('abwehrauftrag');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen WHERE besitzer=$spieler AND status=1 AND id=$baid");
     $array = @mysql_fetch_array($zeiger);
     $baid=$array["id"];
@@ -465,7 +467,7 @@ if ($_GET["fu"]==4) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -1026,20 +1028,20 @@ if ($_GET["fu"]==5) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
-    $falte_cantox=($_POST["falte_cantox"]<0)?0:$_POST["falte_cantox"];
-    $falte_lemin=($_POST["falte_lemin"]<0)?0:$_POST["falte_lemin"];
-    $falte_min1=($_POST["falte_min1"]<0)?0:$_POST["falte_min1"];
-    $falte_min2=($_POST["falte_min2"]<0)?0:$_POST["falte_min2"];
-    $falte_min3=($_POST["falte_min3"]<0)?0:$_POST["falte_min3"];
-    $falte_vorrat=($_POST["falte_vorrat"]<0)?0:$_POST["falte_vorrat"];
-    $planet_cantox=($_POST["planet_cantox"]<0)?0:$_POST["planet_cantox"];
-    $planet_lemin=($_POST["planet_lemin"]<0)?0:$_POST["planet_lemin"];
-    $planet_min1=($_POST["planet_min1"]<0)?0:$_POST["planet_min1"];
-    $planet_min2=($_POST["planet_min2"]<0)?0:$_POST["planet_min2"];
-    $planet_min3=($_POST["planet_min3"]<0)?0:$_POST["planet_min3"];
-    $planet_vorrat=($_POST["planet_vorrat"]<0)?0:$_POST["planet_vorrat"];
+    $falte_cantox=(int_post('falte_cantox')<0)?0:int_post('falte_cantox');
+    $falte_lemin=(int_post('falte_lemin')<0)?0:int_post('falte_lemin');
+    $falte_min1=(int_post('falte_min1')<0)?0:int_post('falte_min1');
+    $falte_min2=(int_post('falte_min2')<0)?0:int_post('falte_min2');
+    $falte_min3=(int_post('falte_min3')<0)?0:int_post('falte_min3');
+    $falte_vorrat=(int_post('falte_vorrat')<0)?0:int_post('falte_vorrat');
+    $planet_cantox=(int_post('planet_cantox')<0)?0:int_post('planet_cantox');
+    $planet_lemin=(int_post('planet_lemin')<0)?0:int_post('planet_lemin');
+    $planet_min1=(int_post('planet_min1')<0)?0:int_post('planet_min1');
+    $planet_min2=(int_post('planet_min2')<0)?0:int_post('planet_min2');
+    $planet_min3=(int_post('planet_min3')<0)?0:int_post('planet_min3');
+    $planet_vorrat=(int_post('planet_vorrat')<0)?0:int_post('planet_vorrat');
     $zielid=$_POST["zielid"];
     $zielart=substr($zielid,0,1);
     $zielid=substr($zielid,1,strlen($zielid)-1);

--- a/inhalt/basen_beta.php
+++ b/inhalt/basen_beta.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='basen_beta';
-$baid=$_GET["baid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'basen_beta';
+$fuid = int_get('fu');
+$baid = int_get('baid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -162,7 +164,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -199,8 +201,8 @@ if ($_GET["fu"]==2) {
     }
     for ($i=0;$i<$zaehler;$i++) {
         $schiffwert=explode(':',$schiff[$i]);
-        if ($schiffwert[1]==$_POST["schiffid"]) {
-            if (($cantox>=$schiffwert[5]) and ($min1>=$schiffwert[6])  and ($min2>=$schiffwert[7])  and ($min3>=$schiffwert[8] and ($schiffwert[2]<=$t_huelle))) {
+        if ($schiffwert[1]==int_post('schiffid')) {
+            if (($cantox>=$schiffwert[5]) and ($min1>=$schiffwert[6]) and ($min2>=$schiffwert[7]) and ($min3>=$schiffwert[8] and ($schiffwert[2]<=$t_huelle))) {
                 $cantox=$cantox-$schiffwert[5];
                 $min1=$min1-$schiffwert[6];
                 $min2=$min2-$schiffwert[7];
@@ -229,7 +231,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -343,8 +345,8 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
-include ("inc.header.php");
+if ($fuid==4) {
+    include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
     $baid=$array["id"];
@@ -381,24 +383,25 @@ include ("inc.header.php");
     $minkosten_1 = array (0,1,2,2,3,3,3,3,13,17);
     $minkosten_2 = array (0,5,5,3,3,3,4,5,3,3);
     $minkosten_3 = array (0,0,1,5,7,7,15,15,28,35);
-    $anzahl=$_POST["anzahl"];
-    if (($cantox>=$kosten[$_POST["stufe"]]*$anzahl) and ($min1>=$minkosten_1[$_POST["stufe"]]*$anzahl)  and ($min2>=$minkosten_2[$_POST["stufe"]]*$anzahl)  and ($min3>=$minkosten_3[$_POST["stufe"]]*$anzahl) and ((($_POST["stufe"]<8)and ($_POST["stufe"]<=$t_antrieb))or(($_POST["stufe"]>7)and ($_POST["stufe"]<$t_antrieb)))) {
-        $cantox=$cantox-($kosten[$_POST["stufe"]]*$anzahl);
-        $min1=$min1-($minkosten_1[$_POST["stufe"]]*$anzahl);
-        $min2=$min2-($minkosten_2[$_POST["stufe"]]*$anzahl);
-        $min3=$min3-($minkosten_3[$_POST["stufe"]]*$anzahl);
-        if ($_POST["stufe"]==1) { $vorrat_antrieb_1=$vorrat_antrieb_1+$anzahl;
-        }elseif ($_POST["stufe"]==2) { $vorrat_antrieb_2=$vorrat_antrieb_2+$anzahl;
-        }elseif ($_POST["stufe"]==3) { $vorrat_antrieb_3=$vorrat_antrieb_3+$anzahl;
-        }elseif ($_POST["stufe"]==4) { $vorrat_antrieb_4=$vorrat_antrieb_4+$anzahl;
-        }elseif ($_POST["stufe"]==5) { $vorrat_antrieb_5=$vorrat_antrieb_5+$anzahl;
-        }elseif ($_POST["stufe"]==6) { $vorrat_antrieb_6=$vorrat_antrieb_6+$anzahl;
-        }elseif ($_POST["stufe"]==7) { $vorrat_antrieb_7=$vorrat_antrieb_7+$anzahl;
-        }elseif ($_POST["stufe"]==8) { $vorrat_antrieb_8=$vorrat_antrieb_8+$anzahl;
-        }elseif ($_POST["stufe"]==9) { $vorrat_antrieb_9=$vorrat_antrieb_9+$anzahl;}
+    $anzahl=int_post('anzahl');
+    $stufe=int_post('stufe');
+    if (($cantox>=$kosten[$stufe]*$anzahl) and ($min1>=$minkosten_1[$stufe]*$anzahl) and ($min2>=$minkosten_2[$stufe]*$anzahl) and ($min3>=$minkosten_3[$stufe]*$anzahl) and ((($stufe<8) and ($stufe<=$t_antrieb)) or (($stufe>7) and ($stufe<$t_antrieb)))) {
+        $cantox=$cantox-($kosten[$stufe]*$anzahl);
+        $min1=$min1-($minkosten_1[$stufe]*$anzahl);
+        $min2=$min2-($minkosten_2[$stufe]*$anzahl);
+        $min3=$min3-($minkosten_3[$stufe]*$anzahl);
+        if ($stufe==1) { $vorrat_antrieb_1=$vorrat_antrieb_1+$anzahl;
+        }elseif ($stufe==2) { $vorrat_antrieb_2=$vorrat_antrieb_2+$anzahl;
+        }elseif ($stufe==3) { $vorrat_antrieb_3=$vorrat_antrieb_3+$anzahl;
+        }elseif ($stufe==4) { $vorrat_antrieb_4=$vorrat_antrieb_4+$anzahl;
+        }elseif ($stufe==5) { $vorrat_antrieb_5=$vorrat_antrieb_5+$anzahl;
+        }elseif ($stufe==6) { $vorrat_antrieb_6=$vorrat_antrieb_6+$anzahl;
+        }elseif ($stufe==7) { $vorrat_antrieb_7=$vorrat_antrieb_7+$anzahl;
+        }elseif ($stufe==8) { $vorrat_antrieb_8=$vorrat_antrieb_8+$anzahl;
+        }elseif ($stufe==9) { $vorrat_antrieb_9=$vorrat_antrieb_9+$anzahl;}
         $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=$cantox,min1=$min1,min2=$min2,min3=$min3 where besitzer=$spieler and id=$planetid");
         $zeiger_temp = @mysql_query("UPDATE $skrupel_sternenbasen set vorrat_antrieb_1=$vorrat_antrieb_1,vorrat_antrieb_2=$vorrat_antrieb_2,vorrat_antrieb_3=$vorrat_antrieb_3,vorrat_antrieb_4=$vorrat_antrieb_4,vorrat_antrieb_5=$vorrat_antrieb_5,vorrat_antrieb_6=$vorrat_antrieb_6,vorrat_antrieb_7=$vorrat_antrieb_7,vorrat_antrieb_8=$vorrat_antrieb_8,vorrat_antrieb_9=$vorrat_antrieb_9 where besitzer=$spieler and id=$baid");
-        $aname=$antriebname[$_POST["stufe"]];
+        $aname=$antriebname[$stufe];
         $message=str_replace(array('{1}','{2}'),array($aname,$anzahl),$lang['basenbeta']['antrieberfolgreichproduziert']);
         $message='<center>'.$message.'</center>';
     }
@@ -419,7 +422,7 @@ include ("inc.header.php");
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -537,7 +540,7 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -577,25 +580,26 @@ if ($_GET["fu"]==6) {
     $minkosten_1 = array (0,0,0,2,12,12,12,12,12,18,12);
     $minkosten_2 = array (0,1,1,1,1,1,1,1,1,1,1);
     $minkosten_3 = array (0,0,0,0,1,5,1,14,30,38,57);
-    $anzahl=$_POST["anzahl"];
-    if (($cantox>=$kosten[$_POST["stufe"]]*$anzahl) and ($min1>=$minkosten_1[$_POST["stufe"]]*$anzahl)  and ($min2>=$minkosten_2[$_POST["stufe"]]*$anzahl)  and ($min3>=$minkosten_3[$_POST["stufe"]]*$anzahl) and ($techlevel[$_POST["stufe"]]<=$t_energie)) {
-        $cantox=$cantox-($kosten[$_POST["stufe"]]*$anzahl);
-        $min1=$min1-($minkosten_1[$_POST["stufe"]]*$anzahl);
-        $min2=$min2-($minkosten_2[$_POST["stufe"]]*$anzahl);
-        $min3=$min3-($minkosten_3[$_POST["stufe"]]*$anzahl);
-        if ($_POST["stufe"]==1) { $vorrat_energetik_1=$vorrat_energetik_1+$anzahl;
-        }elseif ($_POST["stufe"]==2) { $vorrat_energetik_2=$vorrat_energetik_2+$anzahl;
-        }elseif ($_POST["stufe"]==3) { $vorrat_energetik_3=$vorrat_energetik_3+$anzahl;
-        }elseif ($_POST["stufe"]==4) { $vorrat_energetik_4=$vorrat_energetik_4+$anzahl;
-        }elseif ($_POST["stufe"]==5) { $vorrat_energetik_5=$vorrat_energetik_5+$anzahl;
-        }elseif ($_POST["stufe"]==6) { $vorrat_energetik_6=$vorrat_energetik_6+$anzahl;
-        }elseif ($_POST["stufe"]==7) { $vorrat_energetik_7=$vorrat_energetik_7+$anzahl;
-        }elseif ($_POST["stufe"]==8) { $vorrat_energetik_8=$vorrat_energetik_8+$anzahl;
-        }elseif ($_POST["stufe"]==9) { $vorrat_energetik_9=$vorrat_energetik_9+$anzahl;
-        }elseif ($_POST["stufe"]==10) { $vorrat_energetik_10=$vorrat_energetik_10+$anzahl;}
+    $anzahl=int_post('anzahl');
+    $stufe=int_post('stufe');
+    if (($cantox>=$kosten[$stufe]*$anzahl) and ($min1>=$minkosten_1[$stufe]*$anzahl) and ($min2>=$minkosten_2[$stufe]*$anzahl) and ($min3>=$minkosten_3[$stufe]*$anzahl) and ($techlevel[$stufe]<=$t_energie)) {
+        $cantox=$cantox-($kosten[$stufe]*$anzahl);
+        $min1=$min1-($minkosten_1[$stufe]*$anzahl);
+        $min2=$min2-($minkosten_2[$stufe]*$anzahl);
+        $min3=$min3-($minkosten_3[$stufe]*$anzahl);
+        if ($stufe==1) { $vorrat_energetik_1=$vorrat_energetik_1+$anzahl;
+        }elseif ($stufe==2) { $vorrat_energetik_2=$vorrat_energetik_2+$anzahl;
+        }elseif ($stufe==3) { $vorrat_energetik_3=$vorrat_energetik_3+$anzahl;
+        }elseif ($stufe==4) { $vorrat_energetik_4=$vorrat_energetik_4+$anzahl;
+        }elseif ($stufe==5) { $vorrat_energetik_5=$vorrat_energetik_5+$anzahl;
+        }elseif ($stufe==6) { $vorrat_energetik_6=$vorrat_energetik_6+$anzahl;
+        }elseif ($stufe==7) { $vorrat_energetik_7=$vorrat_energetik_7+$anzahl;
+        }elseif ($stufe==8) { $vorrat_energetik_8=$vorrat_energetik_8+$anzahl;
+        }elseif ($stufe==9) { $vorrat_energetik_9=$vorrat_energetik_9+$anzahl;
+        }elseif ($stufe==10) { $vorrat_energetik_10=$vorrat_energetik_10+$anzahl;}
         $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=$cantox,min1=$min1,min2=$min2,min3=$min3 where besitzer=$spieler and id=$planetid");
         $zeiger_temp = @mysql_query("UPDATE $skrupel_sternenbasen set vorrat_energetik_1=$vorrat_energetik_1,vorrat_energetik_2=$vorrat_energetik_2,vorrat_energetik_3=$vorrat_energetik_3,vorrat_energetik_4=$vorrat_energetik_4,vorrat_energetik_5=$vorrat_energetik_5,vorrat_energetik_6=$vorrat_energetik_6,vorrat_energetik_7=$vorrat_energetik_7,vorrat_energetik_8=$vorrat_energetik_8,vorrat_energetik_9=$vorrat_energetik_9,vorrat_energetik_10=$vorrat_energetik_10 where besitzer=$spieler and id=$baid");
-        $message=str_replace(array('{1}','{2}'),array($waffen[$_POST["stufe"]],$anzahl),$lang['basenbeta']['energetikerfolgreichproduziert']);
+        $message=str_replace(array('{1}','{2}'),array($waffen[$stufe],$anzahl),$lang['basenbeta']['energetikerfolgreichproduziert']);
         $message='<center>'.$message.'</center>';
     }
     ?>
@@ -615,7 +619,7 @@ if ($_GET["fu"]==6) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -732,7 +736,7 @@ if ($_GET["fu"]==7) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -772,25 +776,26 @@ if ($_GET["fu"]==8) {
     $minkosten_1 = array (0,1,0,4,3,1,4,7,2,3,1);
     $minkosten_2 = array (0,1,1,1,1,1,1,1,1,1,1);
     $minkosten_3 = array (0,0,0,0,1,5,1,14,7,8,9);
-    $anzahl=$_POST["anzahl"];
-    if (($cantox>=$kosten[$_POST["stufe"]]*$anzahl) and ($min1>=$minkosten_1[$_POST["stufe"]]*$anzahl)  and ($min2>=$minkosten_2[$_POST["stufe"]]*$anzahl)  and ($min3>=$minkosten_3[$_POST["stufe"]]*$anzahl) and ($techlevel[$_POST["stufe"]]<=$t_explosiv)) {
-        $cantox=$cantox-($kosten[$_POST["stufe"]]*$anzahl);
-        $min1=$min1-($minkosten_1[$_POST["stufe"]]*$anzahl);
-        $min2=$min2-($minkosten_2[$_POST["stufe"]]*$anzahl);
-        $min3=$min3-($minkosten_3[$_POST["stufe"]]*$anzahl);
-        if ($_POST["stufe"]==1) { $vorrat_projektile_1=$vorrat_projektile_1+$anzahl;
-        }elseif ($_POST["stufe"]==2) { $vorrat_projektile_2=$vorrat_projektile_2+$anzahl;
-        }elseif ($_POST["stufe"]==3) { $vorrat_projektile_3=$vorrat_projektile_3+$anzahl;
-        }elseif ($_POST["stufe"]==4) { $vorrat_projektile_4=$vorrat_projektile_4+$anzahl;
-        }elseif ($_POST["stufe"]==5) { $vorrat_projektile_5=$vorrat_projektile_5+$anzahl;
-        }elseif ($_POST["stufe"]==6) { $vorrat_projektile_6=$vorrat_projektile_6+$anzahl;
-        }elseif ($_POST["stufe"]==7) { $vorrat_projektile_7=$vorrat_projektile_7+$anzahl;
-        }elseif ($_POST["stufe"]==8) { $vorrat_projektile_8=$vorrat_projektile_8+$anzahl;
-        }elseif ($_POST["stufe"]==9) { $vorrat_projektile_9=$vorrat_projektile_9+$anzahl;
-        }elseif ($_POST["stufe"]==10) { $vorrat_projektile_10=$vorrat_projektile_10+$anzahl;}
+    $anzahl=int_post('anzahl');
+    $stufe=int_post('stufe');
+    if (($cantox>=$kosten[$stufe]*$anzahl) and ($min1>=$minkosten_1[$stufe]*$anzahl) and ($min2>=$minkosten_2[$stufe]*$anzahl) and ($min3>=$minkosten_3[$stufe]*$anzahl) and ($techlevel[$stufe]<=$t_explosiv)) {
+        $cantox=$cantox-($kosten[$stufe]*$anzahl);
+        $min1=$min1-($minkosten_1[$stufe]*$anzahl);
+        $min2=$min2-($minkosten_2[$stufe]*$anzahl);
+        $min3=$min3-($minkosten_3[$stufe]*$anzahl);
+        if ($stufe==1) { $vorrat_projektile_1=$vorrat_projektile_1+$anzahl;
+        }elseif ($stufe==2) { $vorrat_projektile_2=$vorrat_projektile_2+$anzahl;
+        }elseif ($stufe==3) { $vorrat_projektile_3=$vorrat_projektile_3+$anzahl;
+        }elseif ($stufe==4) { $vorrat_projektile_4=$vorrat_projektile_4+$anzahl;
+        }elseif ($stufe==5) { $vorrat_projektile_5=$vorrat_projektile_5+$anzahl;
+        }elseif ($stufe==6) { $vorrat_projektile_6=$vorrat_projektile_6+$anzahl;
+        }elseif ($stufe==7) { $vorrat_projektile_7=$vorrat_projektile_7+$anzahl;
+        }elseif ($stufe==8) { $vorrat_projektile_8=$vorrat_projektile_8+$anzahl;
+        }elseif ($stufe==9) { $vorrat_projektile_9=$vorrat_projektile_9+$anzahl;
+        }elseif ($stufe==10) { $vorrat_projektile_10=$vorrat_projektile_10+$anzahl;}
         $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set cantox=$cantox,min1=$min1,min2=$min2,min3=$min3 where besitzer=$spieler and id=$planetid");
         $zeiger_temp = @mysql_query("UPDATE $skrupel_sternenbasen set vorrat_projektile_1=$vorrat_projektile_1,vorrat_projektile_2=$vorrat_projektile_2,vorrat_projektile_3=$vorrat_projektile_3,vorrat_projektile_4=$vorrat_projektile_4,vorrat_projektile_5=$vorrat_projektile_5,vorrat_projektile_6=$vorrat_projektile_6,vorrat_projektile_7=$vorrat_projektile_7,vorrat_projektile_8=$vorrat_projektile_8,vorrat_projektile_9=$vorrat_projektile_9,vorrat_projektile_10=$vorrat_projektile_10 where besitzer=$spieler and id=$baid");
-        $message=str_replace(array('{1}','{2}'),array($waffen[$_POST["stufe"]],$anzahl),$lang['basenbeta']['projektilerfolgreichproduziert']);
+        $message=str_replace(array('{1}','{2}'),array($waffen[$stufe],$anzahl),$lang['basenbeta']['projektilerfolgreichproduziert']);
         $message='<center>'.$message.'</center>';
     }
     ?>
@@ -810,7 +815,7 @@ if ($_GET["fu"]==8) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -834,7 +839,7 @@ if ($_GET["fu"]==9) {
     $min1=$array2["min1"];
     $min2=$array2["min2"];
     $min3=$array2["min3"];
-    $zeiger3 = @mysql_query("SELECT * FROM $skrupel_konplaene where besitzer=$spieler and spiel=$spiel and id=".$_POST["schiffid"]);
+    $zeiger3 = @mysql_query("SELECT * FROM $skrupel_konplaene where besitzer=$spieler and spiel=$spiel and id=".int_post('schiffid'));
     $array3 = @mysql_fetch_array($zeiger3);
     $konid=$array3["id"];
     $rasses=$array3["rasse"];
@@ -843,7 +848,7 @@ if ($_GET["fu"]==9) {
     $techlevel=$array3["techlevel"];
     $sonstiges=$array3["sonstiges"];
     $schiffwert=explode(':',$sonstiges);
-    if (($cantox>=$schiffwert[2]) and ($min1>=$schiffwert[3])  and ($min2>=$schiffwert[4])  and ($min3>=$schiffwert[5])) {
+    if (($cantox>=$schiffwert[2]) and ($min1>=$schiffwert[3]) and ($min2>=$schiffwert[4]) and ($min3>=$schiffwert[5])) {
         $cantox=$cantox-$schiffwert[2];
         $min1=$min1-$schiffwert[3];
         $min2=$min2-$schiffwert[4];

--- a/inhalt/basen_gamma.php
+++ b/inhalt/basen_gamma.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='basen_gamma';
-$baid=$_GET["baid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'basen_gamma';
+$fuid = int_get('fu');
+$baid = int_get('baid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -64,7 +66,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -82,7 +84,7 @@ if ($_GET["fu"]==2) {
     $defense=$array["defense"];
     $jaeger=$array["jaeger"];
     $art=$array["art"];
-    $zusatz=$_POST['zusatz'];
+    $zusatz=int_post('zusatz');
     if ($art!=3) { $zusatz=0; }
     $vorrat_projektile_1=$array["vorrat_projektile_1"];
     $vorrat_projektile_2=$array["vorrat_projektile_2"];
@@ -113,7 +115,7 @@ if ($_GET["fu"]==2) {
     $vorrat_antrieb_7=$array["vorrat_antrieb_7"];
     $vorrat_antrieb_8=$array["vorrat_antrieb_8"];
     $vorrat_antrieb_9=$array["vorrat_antrieb_9"];
-    $huellenid=$_POST['rumpf'];
+    $huellenid=int_post('rumpf');
     $zeiger2 = @mysql_query("SELECT * FROM $skrupel_huellen where id=$huellenid");
     $array2 = @mysql_fetch_array($zeiger2);
     $hid=$array2["id"];
@@ -373,7 +375,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -402,18 +404,18 @@ if ($_GET["fu"]==3) {
       $native_fert_material=0;
     }
     //natives liefern baumaterial ende
-    $antriebestufe=$_POST['antriebe'];
-    $projektilestufe=$_POST['projektile'];
-    $energetikstufe=$_POST['energetik'];
+    $antriebestufe=int_post('antriebe');
+    $projektilestufe=int_post('projektile');
+    $energetikstufe=int_post('energetik');
     $schiffsname=$_POST['schiffsname'];
-    $zusatz=$_POST['zusatz'];
+    $zusatz=int_post('zusatz');
     $schiffsname=str_replace("'"," ",$schiffsname);
     $schiffsname=str_replace('"'," ",$schiffsname);
     if ($art!=3) { $zusatz=0; }
     if ($projektilestufe>=1) {} else {$projektilestufe=0;}
     if ($energetikstufe>=1) {} else {$energetikstufe=0;}
     if ($antriebestufe>=1) {} else {$antriebestufe=0;}
-    $huellenid=$_POST['rumpf'];
+    $huellenid=int_post('rumpf');
     $zeiger2 = @mysql_query("SELECT * FROM $skrupel_huellen where id=$huellenid");
     $array2 = @mysql_fetch_array($zeiger2);
     $hid=$array2["id"];
@@ -481,7 +483,7 @@ if ($_GET["fu"]==3) {
         <?php echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_sternenbasen where id=$baid");
     $array = @mysql_fetch_array($zeiger);
@@ -518,7 +520,7 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $eintrag=$_POST["logbuchdaten"];
     $eintrag=str_replace("\"", "\'",$eintrag);
@@ -531,12 +533,12 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");
     $array = @mysql_fetch_array($zeiger);
     $art=$array["art"];
-    $huellenid=$_POST['rumpf'];
+    $huellenid=int_post('rumpf');
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" scroll="auto" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <center>

--- a/inhalt/export.php
+++ b/inhalt/export.php
@@ -1,11 +1,14 @@
 <?php
-    if(empty($_GET['fu']))$_GET['fu'] = 1;
-    if ($_GET["fu"]==1) {
-    include ("../inc.conf.php");
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$fuid = int_get('fu');
+if (!$fuid) $fuid=1;
 
-    $breite=$_GET["width"];
-    $hoehe=$_GET["height"];
-    $spiel=$_GET["spiel"];
+if ($fuid==1) {
+
+    $breite=int_get('width');
+    $hoehe=int_get('height');
+    $spiel=int_get('spiel');
 
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
@@ -166,9 +169,8 @@
     @mysql_close();
     }
 
-if ($_GET["fu"]==2) {
-    include ("../inc.conf.php");
-    $spiel=$_GET["spiel"];
+if ($fuid==2) {
+    $spiel=int_get('spiel');
 
 
     $conn = @mysql_connect($server.':'.$port,"$login","$password");

--- a/inhalt/flotte.php
+++ b/inhalt/flotte.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='flotte';
-$shid=$_GET["shid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'flotte';
+$fuid = int_get('fu');
+$shid = int_get('shid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" <?php if (@intval(substr($spieler_optionen,17,1))!=1) { ?>onload="document.getElementById('bodycontent').style.width = (document.getElementById('bodytable').offsetWidth) + 'px';CSBfleXcroll('bodybody');"<?php } ?> style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -40,7 +42,7 @@ if ($_GET["fu"]==1) {
             }
         </script>
         <?php
-        $oid=$_GET["oid"];
+        $oid=int_get('oid');
         if (!$oid) { $oid=0; }
         $total=0;
         $zeiger5 = @mysql_query("SELECT count(*) as total FROM $skrupel_schiffe where besitzer=$spieler and spiel=$spiel");
@@ -313,9 +315,9 @@ if ($_GET["fu"]==1) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
-    $oid=$_GET["oid"];
+    $oid=int_get('oid');
     if (!$oid) {
         $zeiger = @mysql_query("SELECT id,ordner,besitzer FROM $skrupel_schiffe where besitzer=$spieler and id=$shid");
         $array = @mysql_fetch_array($zeiger);
@@ -341,8 +343,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
-    include ("../inc.conf.php");
+if ($fuid==3) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where besitzer=$spieler and id=$shid");
     $schiffanzahl = @mysql_num_rows($zeiger);
@@ -629,7 +630,7 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>
@@ -675,7 +676,7 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -707,7 +708,7 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -742,8 +743,8 @@ if ($_GET["fu"]==6) {
             }
         </script>
         <?php
-        $flottex=$_GET["flottex"];
-        $flottey=$_GET["flottey"];
+        $flottex=int_get('flottex');
+        $flottey=int_get('flottey');
         $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where besitzer=$spieler and status>0 and spiel=$spiel and kox=$flottex and koy=$flottey order by name");
         $schiffanzahl = @mysql_num_rows($zeiger);
         if ($schiffanzahl>=1) {
@@ -991,9 +992,9 @@ if ($_GET["fu"]==6) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
-    $oid=$_GET["oid"];
+    $oid=int_get('oid');
     ?>
     <script language=JavaScript>
         function linksub(url) {
@@ -1033,9 +1034,9 @@ if ($_GET["fu"]==7) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
-    $oid=$_GET["oid"];
+    $oid=int_get('oid');
     ?>
     <script language=JavaScript>
         function linksub(url) {

--- a/inhalt/flotte_alpha.php
+++ b/inhalt/flotte_alpha.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='flotte_alpha';
-$shid=$_GET["shid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'flotte_alpha';
+$fuid = int_get('fu');
+$shid = int_get('shid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT fracht_min2,kox,koy,flug,warp,zielx,ziely,zielid,antrieb,mission,masse_gesamt,lemin FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -325,21 +327,21 @@ if ($_GET["fu"]==1) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $warpfaktor=$_POST["warpfaktor"];
-        $flug=$_POST["flug"];
-        $lemin=$_POST["lemin"];
-        $zielxf=$_POST["zielxf"];
-        $zielyf=$_POST["zielyf"];
-        $koxf=$_POST["koxf"];
-        $koyf=$_POST["koyf"];
-        $zielidf=$_POST["zielidf"];
-        $verbrauchf=$_POST["verbrauchf"];
-        $benzin2=$_POST["benzin2"];
+        $warpfaktor=int_post('warpfaktor');
+        $flug=int_post('flug');
+        $lemin=int_post('lemin');
+        $zielxf=int_post('zielxf');
+        $zielyf=int_post('zielyf');
+        $koxf=int_post('koxf');
+        $koyf=int_post('koyf');
+        $zielidf=int_post('zielidf');
+        $verbrauchf=int_post('verbrauchf');
+        $benzin2=int_post('benzin2');
         $kursmodus=$_POST["pathfind"];
         if ($warpfaktor==0) {
             $flug=0;
@@ -372,7 +374,7 @@ if ($_GET["fu"]==2) {
                 } else {
                     $warp=$warpfaktor;
                     $zielx=$zielxf;
-                    $ziely=$zielyf;                                        
+                    $ziely=$zielyf;
                     $message=$lang['flottealpha']['kursgesichert'];
                     if ($flug==1) {
                         $zielid=0;
@@ -487,7 +489,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     include ("../lang/".$spieler_sprache."/lang.spionagen.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid and besitzer=$spieler");
@@ -1460,15 +1462,14 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $shid=$_GET["shid"];
-        $begleitschutz=$_POST["begleitschutz"];
-        $crewmen=$_POST["crewmen"];
-        $projektile=$_POST["projektile"];
+        $begleitschutz=int_post('begleitschutz');
+        $crewmen=int_post('crewmen');
+        $projektile=int_post('projektile');
         $zeiger = @mysql_query("SELECT id,kox,koy,flug,zielid,warp FROM $skrupel_schiffe where id=$shid");
         $array = @mysql_fetch_array($zeiger);
         $kox=$array["kox"];
@@ -1476,7 +1477,9 @@ if ($_GET["fu"]==4) {
         $flugalt=$array["flug"];
         $zielalt=$array["zielid"];
         $warpalt=$array["warp"];
-        $spezialmission=$_POST["aktion"];
+        $spezialmission=int_post('aktion');
+        $betamodus=int_post('betamodus');
+        $viralziel=int_post('viralziel');
         if ($spezialmission==0) {
             $message=$lang['flottealpha']['speznachricht'][0];
         } elseif ($spezialmission==1) {
@@ -1485,25 +1488,25 @@ if ($_GET["fu"]==4) {
             $message=$lang['flottealpha']['speznachricht'][2];
         } elseif ($spezialmission==3) { 
             $message=$lang['flottealpha']['speznachricht'][3];
-        } elseif (($spezialmission==4) and ($_POST["betamodus"]<>1)) { 
+        } elseif (($spezialmission==4) and ($betamodus<>1)) { 
             $message=$lang['flottealpha']['speznachricht'][4];
-        } elseif (($spezialmission==4) and ($_POST["betamodus"]==1)) {
+        } elseif (($spezialmission==4) and ($betamodus==1)) {
             $spezialmission=27;
             $message=$lang['flottealpha']['speznachricht'][27];
         } elseif ($spezialmission==5) {
             $message=$lang['flottealpha']['speznachricht'][5];
-        } elseif (($spezialmission==6) and ($_POST["betamodus"]<>1)) {
+        } elseif (($spezialmission==6) and ($betamodus<>1)) {
             $message=$lang['flottealpha']['speznachricht'][6];
-        } elseif (($spezialmission==6) and ($_POST["betamodus"]==1)) {
+        } elseif (($spezialmission==6) and ($betamodus==1)) {
             $spezialmission=26;
             $message=$lang['flottealpha']['speznachricht'][26];
         } elseif ($spezialmission==7) {
             $message=$lang['flottealpha']['speznachricht'][7]; 
         } elseif ($spezialmission==8) { 
             $message=$lang['flottealpha']['speznachricht'][8]; 
-        } elseif (($spezialmission==9) and ($_POST["betamodus"]<>1)) {
+        } elseif (($spezialmission==9) and ($betamodus<>1)) {
             $message=$lang['flottealpha']['speznachricht'][9];
-        } elseif (($spezialmission==9) and ($_POST["betamodus"]==1)) { 
+        } elseif (($spezialmission==9) and ($betamodus==1)) { 
             $spezialmission=10;
             $message=$lang['flottealpha']['speznachricht'][10];
         } elseif ($spezialmission==11) {
@@ -1518,20 +1521,20 @@ if ($_GET["fu"]==4) {
             $message=$lang['flottealpha']['speznachricht'][15];
         } elseif ($spezialmission==16) {
             $message=$lang['flottealpha']['speznachricht'][16];
-        } elseif (($spezialmission==17) and ($_POST["viralziel"]<>1)) { 
+        } elseif (($spezialmission==17) and ($viralziel<>1)) { 
             $message=$lang['flottealpha']['speznachricht'][17];
-        } elseif (($spezialmission==17) and ($_POST["viralziel"]==1)) {
+        } elseif (($spezialmission==17) and ($viralziel==1)) {
             $spezialmission=18;
             $message=$lang['flottealpha']['speznachricht'][18];
-        } elseif (($spezialmission==19) and ($_POST["betamodus"]<>1)) {
+        } elseif (($spezialmission==19) and ($betamodus<>1)) {
             $message=$lang['flottealpha']['speznachricht'][19];
-        } elseif (($spezialmission==19) and ($_POST["betamodus"]==1)) {
+        } elseif (($spezialmission==19) and ($betamodus==1)) {
             $spezialmission=28;
             $message=$lang['flottealpha']['speznachricht'][28];
         } elseif ($spezialmission==20) {
             $message=$lang['flottealpha']['speznachricht'][20];
         } elseif ($spezialmission==21) {
-            $traktor_id=$_POST["traktor_id"];
+            $traktor_id=int_post('traktor_id');
             if ($traktor_id>=1) {
                 $message=$lang['flottealpha']['speznachricht'][21]['t'];
                 $zeiger = @mysql_query("UPDATE $skrupel_schiffe set traktor_id=".$traktor_id." where id=$shid");
@@ -1546,7 +1549,7 @@ if ($_GET["fu"]==4) {
             if(@mysql_num_rows($zeiger_extra) == 1) {
                 $ex_extra = @mysql_fetch_array($zeiger_extra);
                 $extra = @explode(":", $ex_extra['extra']);
-                $extra[1] = @intval($crewmen);
+                $extra[1] = $crewmen;
                 $extra_neu = @implode(":", $extra);
                 $zeiger_extra_temp = @mysql_query("UPDATE $skrupel_schiffe set extra='$extra_neu' where id=$shid");
             }
@@ -1558,7 +1561,7 @@ if ($_GET["fu"]==4) {
                 $extra = @explode(":", $ex_extra['extra']);
                 if (strlen($extra[0])==0)  { $extra[0]=''; }
                 if (strlen($extra[1])==0)  { $extra[1]=''; }
-                $extra[2] = @intval($projektile);
+                $extra[2] = $projektile;
                 $extra_neu = @implode(":", $extra);
                 $zeiger_extra_temp = @mysql_query("UPDATE $skrupel_schiffe set extra='$extra_neu' where id=$shid");
             }
@@ -1568,29 +1571,29 @@ if ($_GET["fu"]==4) {
         } elseif ($spezialmission==29) {
             $message=$lang['flottealpha']['speznachricht'][29];
         } elseif ($spezialmission==30) { 
-            $spezialmission=30+$_POST["spielerid"];                //31-40
+            $spezialmission=30+int_post('spielerid');                //31-40
             if ($spezialmission==30){
                 $message=$lang['flottealpha']['speznachricht'][30];
             }else{
-                $message=str_replace('{1}',$spielerfarbe[$_POST["spielerid"]],$lang['flottealpha']['speznachricht'][31]);
+                $message=str_replace('{1}',$spielerfarbe[int_post('spielerid')],$lang['flottealpha']['speznachricht'][31]);
             }
         } elseif ($spezialmission==40) { 
-            $spezialmission=40+$_POST["spielerfarbe"];            //41-50
-            $message=str_replace('{1}',$spielerfarbe[$_POST["spielerfarbe"]],$lang['flottealpha']['speznachricht'][41]);
+            $spezialmission=40+int_post('spielerfarbe');            //41-50
+            $message=str_replace('{1}',$spielerfarbe[int_post('spielerfarbe')],$lang['flottealpha']['speznachricht'][41]);
         } elseif ($module[0] and $spezialmission == 51) {
             $zeiger_spionage = @mysql_query("SELECT extra FROM $skrupel_schiffe where besitzer=$spieler and id=$shid and volk='unknown' and klasseid=1");
             if(@mysql_num_rows($zeiger_spionage) == 1) {
                 $spionage = @mysql_fetch_array($zeiger_spionage);
                 $extra = @explode(":", $spionage['extra']);
                 $extra_spio = @explode("-", $extra[0]);
-                $extra_spio[3] = @intval($_POST['spionage_id']);
+                $extra_spio[3] = int_post('spionage_id');
                 $extra[0] = @implode("-", $extra_spio);
                 $extra_neu = @implode(":", $extra);
                 $zeiger_spionage_temp = @mysql_query("UPDATE $skrupel_schiffe set extra='$extra_neu' where id=$shid");
             }
             $message = $lang['flottealpha']['speznachricht'][51];
         } elseif ($spezialmission==61) {
-            $spezialmission=$_POST["overdrive"];
+            $spezialmission=int_post('overdrive');
             $message=$lang['flottealpha']['speznachricht'][61];
         } elseif ($spezialmission==70) {
             $message=$lang['flottealpha']['speznachricht'][70];
@@ -1621,8 +1624,8 @@ if ($_GET["fu"]==4) {
             }
         }
         $zeiger = @mysql_query("UPDATE $skrupel_schiffe set spezialmission=".$spezialmission." where id=$shid");
-        $zielid=$_POST["schiff_id"];
-        $warp=$_POST["warpfaktor"];
+        $zielid=int_post('schiff_id');
+        $warp=int_post('warpfaktor');
         if (($begleitschutz==1) and (($flugalt!=4) or ($zielalt!=$zielid) or ($warpalt!=$warp))) {
             $flug=4;
             $zeiger = @mysql_query("SELECT id,kox,koy,name FROM $skrupel_schiffe where id=$zielid");
@@ -1702,7 +1705,7 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT id,routing_status,status,kox,koy FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -1742,7 +1745,7 @@ if ($_GET["fu"]==5) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -1765,29 +1768,29 @@ if ($_GET["fu"]==6) {
     $routing_id="";
     $routing_koord="";
     if(urldecode($_POST["submitbutton"]) == utf8_encode(html_entity_decode($lang['flottealpha']['uebernehmen']))){
-        for($i=0;$i<$_POST["points"];$i++){
-            if($_POST["pid_".$i]!=-1){
-                $routing_mins=$routing_mins.$_POST["cantox_".$i].$_POST["vorrat_".$i].$_POST["lem_".$i].$_POST["bax_".$i].$_POST["ren_".$i].$_POST["vor_".$i].$_POST["vol_".$i];
-                $temp_1=$_POST["kol_".$i];
+        for($i=0;$i<int_post('points');$i++){
+            if(int_post('pid_'.$i)!=-1){
+                $routing_mins=$routing_mins.int_post('cantox_'.$i).int_post('vorrat_'.$i).int_post('lem_'.$i).int_post('bax_'.$i).int_post('ren_'.$i).int_post('vor_'.$i).int_post('vol_'.$i);
+                $temp_1=int_post('kol_'.$i);
                 for($j=1000000;$j>=1;$j=$j/10){
                     $temp_2=(int)($temp_1/$j);
                     $temp_1=$temp_1-($temp_2*$j);
                     $routing_mins=$routing_mins.$temp_2;
                 }
-                $temp_1=$_POST["lbt_".$i];
+                $temp_1=int_post('lbt_'.$i);
                 for($j=1000;$j>=1;$j=$j/10){
                     $temp_2=(int)($temp_1/$j);
                     $temp_1=$temp_1-($temp_2*$j);
                     $routing_mins=$routing_mins.$temp_2;
                 }
-                $temp_1=$_POST["sbt_".$i];
+                $temp_1=int_post('sbt_'.$i);
                 for($j=1000;$j>=1;$j=$j/10){
                     $temp_2=(int)($temp_1/$j);
                     $temp_1=$temp_1-($temp_2*$j);
                     $routing_mins=$routing_mins.$temp_2;
                 }
                 $routing_mins=$routing_mins.":";
-                $pid_a=$_POST["pid_".$i];
+                $pid_a=int_post('pid_'.$i);
                 $zeiger = @mysql_query("SELECT x_pos,y_pos FROM $skrupel_planeten where besitzer=$spieler and id=$pid_a and spiel=$spiel order by name");
                 $ok = @mysql_data_seek($zeiger,0);
                 $array = @mysql_fetch_array($zeiger);
@@ -1797,9 +1800,9 @@ if ($_GET["fu"]==6) {
                     $zielx=$array["x_pos"];
                     $ziely=$array["y_pos"];
                     $flug=(($zielx==$kox)and($ziely==$koy))?0:2;
-                    $zielid=$_POST["pid_".$i];
+                    $zielid=int_post('pid_'.$i);
                 }
-                $routing_id=$routing_id.$_POST["pid_".$i].":";
+                $routing_id=$routing_id.int_post('pid_'.$i).":";
                 $routing_koord=$routing_koord.$x_pos.":".$y_pos."::";
             }
         }
@@ -1864,7 +1867,7 @@ if ($_GET["fu"]==6) {
                         $points=count($routing_id)-1;
                         $j=0;
                         for($i=$routing_schritt;$i<$points;$i++){
-                            $_POST["pid_".$j]=$routing_id[$i];                        
+                            $_POST["pid_".$j]=$routing_id[$i];
                             ?>
                             <input type="hidden" name="pid_<?php echo $j; ?>" value=<?php echo $routing_id[$i]; ?>>
                             <input type="hidden" name="cantox_<?php echo $j; ?>" value=<?php echo substr($routing_mins[$i],0,1); ?>>
@@ -1910,74 +1913,74 @@ if ($_GET["fu"]==6) {
                         $lbt_a=substr($routing_mins[$i],14,4);
                         $sbt_a=substr($routing_mins[$i],18,4);
                     }elseif(urldecode($_POST["submitbutton"])==utf8_encode(html_entity_decode($lang['flottealpha']['loeschen']))){
-                        $point=$_POST["point"];
-                        $points=$_POST["points"]-1;
+                        $point=int_post('point');
+                        $points=int_post('points')-1;
                         for($i=0;$i<$point;$i++){
-                            $pid_h[$i]=$_POST["pid_".$i];
+                            $pid_h[$i]=int_post('pid_'.$i);
                             ?>
-                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo $_POST["pid_".$i]; ?>>
-                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo $_POST["cantox_".$i]; ?>>
-                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo $_POST["vorrat_".$i]; ?>>
-                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo $_POST["lem_".$i]; ?>>
-                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo $_POST["bax_".$i]; ?>>
-                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo $_POST["ren_".$i]; ?>>
-                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo $_POST["vor_".$i]; ?>>
-                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo $_POST["vol_".$i]; ?>>
-                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo $_POST["kol_".$i]; ?>>
-                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo $_POST["lbt_".$i]; ?>>
-                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo $_POST["sbt_".$i]; ?>>
+                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo int_post('pid_'.$i); ?>>
+                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo int_post('cantox_'.$i); ?>>
+                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo int_post('vorrat_'.$i); ?>>
+                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo int_post('lem_'.$i); ?>>
+                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo int_post('bax_'.$i); ?>>
+                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo int_post('ren_'.$i); ?>>
+                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo int_post('vor_'.$i); ?>>
+                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo int_post('vol_'.$i); ?>>
+                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo int_post('kol_'.$i); ?>>
+                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo int_post('lbt_'.$i); ?>>
+                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo int_post('sbt_'.$i); ?>>
                             <?php
                         }
                         for($i=$point+1;$i<$points+1;$i++){
-                            $pid_h[$i-1]=$_POST["pid_".$i];
+                            $pid_h[$i-1]=int_post('pid_'.$i);
                             ?>
-                            <input type="hidden" name="pid_<?php echo $i-1; ?>" value=<?php echo $_POST["pid_".$i]; ?>>
-                            <input type="hidden" name="cantox_<?php echo $i-1; ?>" value=<?php echo $_POST["cantox_".$i]; ?>>
-                            <input type="hidden" name="vorrat_<?php echo $i-1; ?>" value=<?php echo $_POST["vorrat_".$i]; ?>>
-                            <input type="hidden" name="lem_<?php echo $i-1; ?>" value=<?php echo $_POST["lem_".$i]; ?>>
-                            <input type="hidden" name="bax_<?php echo $i-1; ?>" value=<?php echo $_POST["bax_".$i]; ?>>
-                            <input type="hidden" name="ren_<?php echo $i-1; ?>" value=<?php echo $_POST["ren_".$i]; ?>>
-                            <input type="hidden" name="vor_<?php echo $i-1; ?>" value=<?php echo $_POST["vor_".$i]; ?>>
-                            <input type="hidden" name="vol_<?php echo $i-1; ?>" value=<?php echo $_POST["vol_".$i]; ?>>
-                            <input type="hidden" name="kol_<?php echo $i-1; ?>" value=<?php echo $_POST["kol_".$i]; ?>>
-                            <input type="hidden" name="lbt_<?php echo $i-1; ?>" value=<?php echo $_POST["lbt_".$i]; ?>>
-                            <input type="hidden" name="sbt_<?php echo $i-1; ?>" value=<?php echo $_POST["sbt_".$i]; ?>>
+                            <input type="hidden" name="pid_<?php echo $i-1; ?>" value=<?php echo int_post('pid_'.$i); ?>>
+                            <input type="hidden" name="cantox_<?php echo $i-1; ?>" value=<?php echo int_post('cantox_'.$i); ?>>
+                            <input type="hidden" name="vorrat_<?php echo $i-1; ?>" value=<?php echo int_post('vorrat_'.$i); ?>>
+                            <input type="hidden" name="lem_<?php echo $i-1; ?>" value=<?php echo int_post('lem_'.$i); ?>>
+                            <input type="hidden" name="bax_<?php echo $i-1; ?>" value=<?php echo int_post('bax_'.$i); ?>>
+                            <input type="hidden" name="ren_<?php echo $i-1; ?>" value=<?php echo int_post('ren_'.$i); ?>>
+                            <input type="hidden" name="vor_<?php echo $i-1; ?>" value=<?php echo int_post('vor_'.$i); ?>>
+                            <input type="hidden" name="vol_<?php echo $i-1; ?>" value=<?php echo int_post('vol_'.$i); ?>>
+                            <input type="hidden" name="kol_<?php echo $i-1; ?>" value=<?php echo int_post('kol_'.$i); ?>>
+                            <input type="hidden" name="lbt_<?php echo $i-1; ?>" value=<?php echo int_post('lbt_'.$i); ?>>
+                            <input type="hidden" name="sbt_<?php echo $i-1; ?>" value=<?php echo int_post('sbt_'.$i); ?>>
                             <?php
                         }
                         $i=$point+1;
                         $i=($point==$points)?$point-1:$i;
-                        $pid_a=$_POST["pid_".$i];
-                        $cantox_a=$_POST["cantox_".$i];
-                        $vorrat_a=$_POST["vorrat_".$i];
-                        $lem_a=$_POST["lem_".$i];
-                        $bax_a=$_POST["bax_".$i];
-                        $ren_a=$_POST["ren_".$i];
-                        $vor_a=$_POST["vor_".$i];
-                        $vol_a=$_POST["vol_".$i];
-                        $kol_a=$_POST["kol_".$i];
-                        $lbt_a=$_POST["lbt_".$i];
-                        $sbt_a=$_POST["sbt_".$i];
+                        $pid_a=int_post('pid_'.$i);
+                        $cantox_a=int_post('cantox_'.$i);
+                        $vorrat_a=int_post('vorrat_'.$i);
+                        $lem_a=int_post('lem_'.$i);
+                        $bax_a=int_post('bax_'.$i);
+                        $ren_a=int_post('ren_'.$i);
+                        $vor_a=int_post('vor_'.$i);
+                        $vol_a=int_post('vol_'.$i);
+                        $kol_a=int_post('kol_'.$i);
+                        $lbt_a=int_post('lbt_'.$i);
+                        $sbt_a=int_post('sbt_'.$i);
                         $point=($point==$points)?$point-1:$point;
                         for($i=0;$i<$points;$i++){
                             $_POST["pid_".$i]=$pid_h[$i];
                         }
                     }elseif(urldecode($_POST["submitbutton"])==utf8_encode(html_entity_decode($lang['flottealpha']['neuerpunkt']))){
-                        $point=$_POST["point"]+1;
-                        $points=$_POST["points"]+1;
+                        $point=int_post('point')+1;
+                        $points=int_post('points')+1;
                         for($i=0;$i<$point;$i++){
-                            $pid_h[$i]=$_POST["pid_".$i];
+                            $pid_h[$i]=int_post('pid_'.$i);
                             ?>
-                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo $_POST["pid_".$i]; ?>>
-                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo $_POST["cantox_".$i]; ?>>
-                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo $_POST["vorrat_".$i]; ?>>
-                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo $_POST["lem_".$i]; ?>>
-                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo $_POST["bax_".$i]; ?>>
-                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo $_POST["ren_".$i]; ?>>
-                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo $_POST["vor_".$i]; ?>>
-                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo $_POST["vol_".$i]; ?>>
-                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo $_POST["kol_".$i]; ?>>
-                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo $_POST["lbt_".$i]; ?>>
-                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo $_POST["sbt_".$i]; ?>>
+                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo int_post('pid_'.$i); ?>>
+                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo int_post('cantox_'.$i); ?>>
+                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo int_post('vorrat_'.$i); ?>>
+                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo int_post('lem_'.$i); ?>>
+                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo int_post('bax_'.$i); ?>>
+                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo int_post('ren_'.$i); ?>>
+                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo int_post('vor_'.$i); ?>>
+                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo int_post('vol_'.$i); ?>>
+                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo int_post('kol_'.$i); ?>>
+                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo int_post('lbt_'.$i); ?>>
+                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo int_post('sbt_'.$i); ?>>
                             <?php
                         }
                         $pid_h[$point]=-1;
@@ -1995,68 +1998,68 @@ if ($_GET["fu"]==6) {
                         <input type="hidden" name="sbt_<?php echo $point; ?>" value=0>
                         <?php
                         for($i=$point;$i<$points-1;$i++){
-                            $pid_h[$i+1]=$_POST["pid_".$i];
+                            $pid_h[$i+1]=int_post('pid_'.$i);
                             ?>
-                            <input type="hidden" name="pid_<?php echo $i+1; ?>" value=<?php echo $_POST["pid_".$i]; ?>>
-                            <input type="hidden" name="cantox_<?php echo $i+1; ?>" value=<?php echo $_POST["cantox_".$i]; ?>>
-                            <input type="hidden" name="vorrat_<?php echo $i+1; ?>" value=<?php echo $_POST["vorrat_".$i]; ?>>
-                            <input type="hidden" name="lem_<?php echo $i+1; ?>" value=<?php echo $_POST["lem_".$i]; ?>>
-                            <input type="hidden" name="bax_<?php echo $i+1; ?>" value=<?php echo $_POST["bax_".$i]; ?>>
-                            <input type="hidden" name="ren_<?php echo $i+1; ?>" value=<?php echo $_POST["ren_".$i]; ?>>
-                            <input type="hidden" name="vor_<?php echo $i+1; ?>" value=<?php echo $_POST["vor_".$i]; ?>>
-                            <input type="hidden" name="vol_<?php echo $i+1; ?>" value=<?php echo $_POST["vol_".$i]; ?>>
-                            <input type="hidden" name="kol_<?php echo $i+1; ?>" value=<?php echo $_POST["kol_".$i]; ?>>
-                            <input type="hidden" name="lbt_<?php echo $i+1; ?>" value=<?php echo $_POST["lbt_".$i]; ?>>
-                            <input type="hidden" name="sbt_<?php echo $i+1; ?>" value=<?php echo $_POST["sbt_".$i]; ?>>
+                            <input type="hidden" name="pid_<?php echo $i+1; ?>" value=<?php echo int_post('pid_'.$i); ?>>
+                            <input type="hidden" name="cantox_<?php echo $i+1; ?>" value=<?php echo int_post('cantox_'.$i); ?>>
+                            <input type="hidden" name="vorrat_<?php echo $i+1; ?>" value=<?php echo int_post('vorrat_'.$i); ?>>
+                            <input type="hidden" name="lem_<?php echo $i+1; ?>" value=<?php echo int_post('lem_'.$i); ?>>
+                            <input type="hidden" name="bax_<?php echo $i+1; ?>" value=<?php echo int_post('bax_'.$i); ?>>
+                            <input type="hidden" name="ren_<?php echo $i+1; ?>" value=<?php echo int_post('ren_'.$i); ?>>
+                            <input type="hidden" name="vor_<?php echo $i+1; ?>" value=<?php echo int_post('vor_'.$i); ?>>
+                            <input type="hidden" name="vol_<?php echo $i+1; ?>" value=<?php echo int_post('vol_'.$i); ?>>
+                            <input type="hidden" name="kol_<?php echo $i+1; ?>" value=<?php echo int_post('kol_'.$i); ?>>
+                            <input type="hidden" name="lbt_<?php echo $i+1; ?>" value=<?php echo int_post('lbt_'.$i); ?>>
+                            <input type="hidden" name="sbt_<?php echo $i+1; ?>" value=<?php echo int_post('sbt_'.$i); ?>>
                             <?php
                         }
                         for($i=0;$i<$points;$i++){
                             $_POST["pid_".$i]=$pid_h[$i];
                         }
                     }else{
-                        $point=$_POST["point"];
+                        $point=int_post('point');
+                        $points=int_post('points');
                         if($_POST["submitbutton"]=="<"){
-                            if($_POST["point"]>0){
-                                $point=$_POST["point"]-1;
+                            if($point>0){
+                                $point=$point-1;
                             }else{
-                                $point=$_POST["points"]-1;
+                                $point=$points-1;
                             }
                         }elseif($_POST["submitbutton"]==">"){
-                            if($_POST["point"]<$_POST["points"]-1){
-                                $point=$_POST["point"]+1;
+                            if($point<$points-1){
+                                $point=$point+1;
                             }else{
                                 $point=0;
                             }
                         }
-                        $points=$_POST["points"];
                         for($i=0;$i<$points;$i++){
                             ?>
-                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo $_POST["pid_".$i]; ?>>
-                            <input type="hidden" name="kox_<?php echo $i; ?>" value=<?php echo $_POST["kox_".$i]; ?>>
-                            <input type="hidden" name="koy_<?php echo $i; ?>" value=<?php echo $_POST["koy_".$i]; ?>>
-                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo $_POST["cantox_".$i]; ?>>
-                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo $_POST["vorrat_".$i]; ?>>
-                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo $_POST["lem_".$i]; ?>>
-                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo $_POST["bax_".$i]; ?>>
-                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo $_POST["ren_".$i]; ?>>
-                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo $_POST["vor_".$i]; ?>>
-                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo $_POST["vol_".$i]; ?>>
-                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo $_POST["kol_".$i]; ?>>
-                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo $_POST["lbt_".$i]; ?>>
-                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo $_POST["sbt_".$i]; ?>>
+                            <input type="hidden" name="pid_<?php echo $i; ?>" value=<?php echo int_post('pid_'.$i); ?>>
+                            <input type="hidden" name="kox_<?php echo $i; ?>" value=<?php echo int_post('kox_'.$i); ?>>
+                            <input type="hidden" name="koy_<?php echo $i; ?>" value=<?php echo int_post('koy_'.$i); ?>>
+                            <input type="hidden" name="cantox_<?php echo $i; ?>" value=<?php echo int_post('cantox_'.$i); ?>>
+                            <input type="hidden" name="vorrat_<?php echo $i; ?>" value=<?php echo int_post('vorrat_'.$i); ?>>
+                            <input type="hidden" name="lem_<?php echo $i; ?>" value=<?php echo int_post('lem_'.$i); ?>>
+                            <input type="hidden" name="bax_<?php echo $i; ?>" value=<?php echo int_post('bax_'.$i); ?>>
+                            <input type="hidden" name="ren_<?php echo $i; ?>" value=<?php echo int_post('ren_'.$i); ?>>
+                            <input type="hidden" name="vor_<?php echo $i; ?>" value=<?php echo int_post('vor_'.$i); ?>>
+                            <input type="hidden" name="vol_<?php echo $i; ?>" value=<?php echo int_post('vol_'.$i); ?>>
+                            <input type="hidden" name="kol_<?php echo $i; ?>" value=<?php echo int_post('kol_'.$i); ?>>
+                            <input type="hidden" name="lbt_<?php echo $i; ?>" value=<?php echo int_post('lbt_'.$i); ?>>
+                            <input type="hidden" name="sbt_<?php echo $i; ?>" value=<?php echo int_post('sbt_'.$i); ?>>
                             <?php
                         }
-                        $pid_a=$_POST["pid_".$point];
-                        $cantox_a=$_POST["cantox_".$point];
-                        $vorrat_a=$_POST["vorrat_".$point];
-                        $lem_a=$_POST["lem_".$point];
-                        $bax_a=$_POST["bax_".$point];
-                        $ren_a=$_POST["ren_".$point];
-                        $vor_a=$_POST["vor_".$point];
-                        $vol_a=$_POST["vol_".$point];
-                        $kol_a=$_POST["kol_".$point];
-                        $lbt_a=$_POST["lbt_".$point];
-                        $sbt_a=$_POST["sbt_".$point];
+                        $pid_a=int_post('pid_'.$point);
+                        $cantox_a=int_post('cantox_'.$point);
+                        $vorrat_a=int_post('vorrat_'.$point);
+                        $lem_a=int_post('lem_'.$point);
+                        $bax_a=int_post('bax_'.$point);
+                        $ren_a=int_post('ren_'.$point);
+                        $vor_a=int_post('vor_'.$point);
+                        $vol_a=int_post('vol_'.$point);
+                        $kol_a=int_post('kol_'.$point);
+                        $lbt_a=int_post('lbt_'.$point);
+                        $sbt_a=int_post('sbt_'.$point);
                     }
                     if($points>1){
                         if((0<$point)&&($point<$points-1)){
@@ -2084,7 +2087,7 @@ if ($_GET["fu"]==6) {
                                     $array = @mysql_fetch_array($zeiger);
                                     $piid=$array["id"];
                                     $name=$array["name"];
-                                    if(($piid<>$_POST["pid_".$davor])&&($piid<>$_POST["pid_".$danach])&&($piid<>$pid_a))echo "<option value='$piid'>$name</option>";
+                                    if(($piid<>int_post('pid_'.$davor))&&($piid<>int_post('pid_'.$danach))&&($piid<>$pid_a))echo "<option value='$piid'>$name</option>";
                                     if($piid==$pid_a)echo "<option value='$piid' selected>$name</option>";
                                 }
                             }
@@ -2305,15 +2308,15 @@ if ($_GET["fu"]==6) {
     }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
     $routing_mins=$_POST["routing_mins"];
     $routing_id=$_POST["routing_id"];
     $routing_koord=$_POST["routing_koord"];
-    $zielx=$_POST["zielx"];
-    $ziely=$_POST["ziely"];
-    $zielid=$_POST["zielid"];
-    $flug=$_POST["flug"];
+    $zielx=int_post('zielx');
+    $ziely=int_post('ziely');
+    $zielid=int_post('zielid');
+    $flug=int_post('flug');
     if ($_POST["submitbutton"]==$lang['flottealpha']['routeabschliessen']) {
         $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
         $array = @mysql_fetch_array($zeiger);
@@ -2332,8 +2335,8 @@ if ($_GET["fu"]==7) {
                         <td><form name="formular" id="formular"  method="post" action="flotte_alpha.php?fu=8&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>"></td>
                         <td><?php echo $lang['flottealpha']['flugoptionen']; ?></td>
                         <td>
-                            <input type="hidden" name="kox" value=<?php echo $_POST["kox"]; ?>>
-                            <input type="hidden" name="koy" value=<?php echo $_POST["koy"]; ?>>
+                            <input type="hidden" name="kox" value=<?php echo int_post('kox'); ?>>
+                            <input type="hidden" name="koy" value=<?php echo int_post('koy'); ?>>
                             <input type="hidden" name="routing_mins" value="<?php echo $routing_mins?>">
                             <input type="hidden" name="routing_id" value="<?php echo $routing_id; ?>">
                             <input type="hidden" name="routing_koord" value="<?php echo $routing_koord; ?>">
@@ -2419,24 +2422,24 @@ if ($_GET["fu"]==7) {
         } 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
     $zeiger = @mysql_query("UPDATE $skrupel_schiffe set routing_id=\"".$_POST["routing_id"]."\",
                                                      routing_koord=\"".$_POST["routing_koord"]."\",
                                                      routing_mins=\"".$_POST["routing_mins"]."\",
                                                      routing_status=2,
                                                      routing_schritt=0,
-                                                     routing_warp=".$_POST["warpfaktor"].",
-                                                     routing_tank=".$_POST["tank"].",
-                                                     routing_rohstoff=".$_POST["rohstoff"]." where id=$shid");
-    $zeiger_temp = @mysql_query("UPDATE $skrupel_schiffe set flug=".$_POST["flug"].",warp=".$_POST["warpfaktor"].",plasmawarp=0,zielx=".$_POST["zielx"].",ziely=".$_POST["ziely"].",zielid=".$_POST["zielid"]." where id=$shid");
+                                                     routing_warp=".int_post('warpfaktor').",
+                                                     routing_tank=".int_post('tank').",
+                                                     routing_rohstoff=".int_post('rohstoff')." where id=$shid");
+    $zeiger_temp = @mysql_query("UPDATE $skrupel_schiffe set flug=".int_post('flug').",warp=".int_post('warpfaktor').",plasmawarp=0,zielx=".int_post('zielx').",ziely=".int_post('ziely').",zielid=".int_post('zielid')." where id=$shid");
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <br><br><br>
         <center><?php echo $lang['flottealpha']['routeerfolgreich']; ?></center>
         <script language=JavaScript>
             <?php
-            if (($_POST["kox"]==$_POST["zielx"]) and ($_POST["koy"]==$_POST["ziely"])) {
+            if ((int_post('kox')==int_post('zielx')) and (int_post('koy')==int_post('ziely'))) {
                 for ($k=1;$k<=20;$k++) {
                     ?>
                     parent.parent.mittemitte.document.getElementById('punkt_<?php echo $k; ?>_<?php echo $shid; ?>').style.left=0;
@@ -2450,10 +2453,10 @@ if ($_GET["fu"]==8) {
                 parent.parent.mittemitte.document.getElementById('auswahlrand_<?php echo $shid; ?>').style.visibility='hidden';
                 <?php
             } else {
-                $schrittx=($_POST["zielx"]-$_POST["kox"])/20;
-                $schritty=($_POST["ziely"]-$_POST["koy"])/20;
-                $laufx=$_POST["kox"];
-                $laufy=$_POST["koy"];
+                $schrittx=(int_post('zielx')-int_post('kox'))/20;
+                $schritty=(int_post('ziely')-int_post('koy'))/20;
+                $laufx=int_post('kox');
+                $laufy=int_post('koy');
                 for ($k=1;$k<=20;$k++) {
                     $laufx=$laufx+$schrittx;
                     $laufy=$laufy+$schritty;

--- a/inhalt/flotte_beta.php
+++ b/inhalt/flotte_beta.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='flotte_beta';
-$shid=$_GET["shid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'flotte_beta';
+$fuid = int_get('fu');
+$shid = int_get('shid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $p_zahl=0;
     $s_zahl=0;
@@ -246,11 +248,11 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     include ("../lang/".$spieler_sprache."/lang.basen.php");
 
-    $pid=$_GET["pid"];
+    $pid=int_get('pid');
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where id=$pid");
 
@@ -441,7 +443,7 @@ if ($_GET["fu"]==2) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
@@ -651,7 +653,7 @@ if ($_GET["fu"]==3) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -1603,15 +1605,15 @@ if ($_GET["fu"]==4) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $pid=$_GET["pid"];
+        $pid=int_get('pid');
         $zeiger_temp = @mysql_query("SELECT * FROM $skrupel_planeten where id=$pid");
         $array_temp = @mysql_fetch_array($zeiger_temp);
-    
+
         $planet_name=$array_temp["name"];
         $besitzer=$array_temp["besitzer"];
         $s_x_pos=$array_temp["x_pos"];
@@ -1634,44 +1636,26 @@ if ($_GET["fu"]==5) {
         $s_planet_min1=$array_temp["min1"];
         $s_planet_min2=$array_temp["min2"];
         $s_planet_min3=$array_temp["min3"];
-        $planet_kolonisten=$_POST["planet_kolonisten"];
-        $planet_cantox=$_POST["planet_cantox"];
-        $planet_vorrat=$_POST["planet_vorrat"];
-        $planet_lemin=$_POST["planet_lemin"];
-        $planet_min1=$_POST["planet_min1"];
-        $planet_min2=$_POST["planet_min2"];
-        $planet_min3=$_POST["planet_min3"];
-        $fracht_leute=$_POST["fracht_leute"];
-        $fracht_cantox=$_POST["fracht_cantox"];
-        $fracht_vorrat=$_POST["fracht_vorrat"];
-        $fracht_lemin=$_POST["fracht_lemin"];
-        $fracht_min1=$_POST["fracht_min1"];
-        $fracht_min2=$_POST["fracht_min2"];
-        $fracht_min3=$_POST["fracht_min3"];
-        $s_leichtebt=$_POST["s_leichtebt"];
-        $s_schwerebt=$_POST["s_schwerebt"];
-        $p_leichtebt=$_POST["p_leichtebt"];
-        $p_schwerebt=$_POST["p_schwerebt"];
-        
-        if (!ctype_digit($planet_kolonisten)) $planet_kolonisten = 0;
-        if (!ctype_digit($planet_cantox)) $planet_cantox = 0;
-        if (!ctype_digit($planet_vorrat)) $planet_vorrat = 0;
-        if (!ctype_digit($planet_lemin)) $planet_lemin = 0;
-        if (!ctype_digit($planet_min1)) $planet_min1 = 0;
-        if (!ctype_digit($planet_min2)) $planet_min2 = 0;
-        if (!ctype_digit($planet_min3)) $planet_min3 = 0;
-        if (!ctype_digit($fracht_leute)) $fracht_leute = 0;
-        if (!ctype_digit($fracht_cantox)) $fracht_cantox = 0;
-        if (!ctype_digit($fracht_vorrat)) $fracht_vorrat = 0;
-        if (!ctype_digit($fracht_lemin)) $fracht_lemin = 0;
-        if (!ctype_digit($fracht_min1)) $fracht_min1 = 0;
-        if (!ctype_digit($fracht_min2)) $fracht_min2 = 0;
-        if (!ctype_digit($fracht_min3)) $fracht_min3 = 0;
-        if (!ctype_digit($s_leichtebt)) $s_leichtebt = 0;
-        if (!ctype_digit($s_schwerebt)) $s_schwerebt = 0;
-        if (!ctype_digit($p_leichtebt)) $p_leichtebt = 0;
-        if (!ctype_digit($p_schwerebt)) $p_schwerebt = 0;
-    
+
+        $planet_kolonisten = (!int_post('planet_kolonisten'))?0:int_post('planet_kolonisten');
+        $planet_cantox = (!int_post('planet_cantox'))?0:int_post('planet_cantox');
+        $planet_vorrat = (!int_post('planet_vorrat'))?0:int_post('planet_vorrat');
+        $planet_lemin = (!int_post('planet_lemin'))?0:int_post('planet_lemin');
+        $planet_min1 = (!int_post('planet_min1'))?0:int_post('planet_min1');
+        $planet_min2 = (!int_post('planet_min2'))?0:int_post('planet_min2');
+        $planet_min3 = (!int_post('planet_min3'))?0:int_post('planet_min3');
+        $fracht_leute = (!int_post('fracht_leute'))?0:int_post('fracht_leute');
+        $fracht_cantox = (!int_post('fracht_cantox'))?0:int_post('fracht_cantox');
+        $fracht_vorrat = (!int_post('fracht_vorrat'))?0:int_post('fracht_vorrat');
+        $fracht_lemin = (!int_post('fracht_lemin'))?0:int_post('fracht_lemin');
+        $fracht_min1 = (!int_post('fracht_min1'))?0:int_post('fracht_min1');
+        $fracht_min2 = (!int_post('fracht_min2'))?0:int_post('fracht_min2');
+        $fracht_min3 = (!int_post('fracht_min3'))?0:int_post('fracht_min3');
+        $p_leichtebt = (!int_post('p_leichtebt'))?0:int_post('p_leichtebt');
+        $p_schwerebt = (!int_post('p_schwerebt'))?0:int_post('p_schwerebt');
+        $s_leichtebt = (!int_post('s_leichtebt'))?0:int_post('s_leichtebt');
+        $s_schwerebt = (!int_post('s_schwerebt'))?0:int_post('s_schwerebt');
+
         if (($planet_kolonisten>=0) and ($p_leichtebt>=0) and ($p_schwerebt>=0) and ($planet_cantox>=0) and ($planet_vorrat>=0) and ($planet_lemin>=0) and ($planet_min1>=0) and ($planet_min2>=0) and ($planet_min3>=0) and ($fracht_leute>=0) and ($s_leichtebt>=0) and ($s_schwerebt>=0) and ($fracht_cantox>=0) and ($fracht_vorrat>=0) and ($fracht_lemin>=0) and ($fracht_min1>=0) and ($fracht_min2>=0) and ($fracht_min3>=0)) {
             $s_zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
             $s_array = @mysql_fetch_array($s_zeiger);
@@ -1773,7 +1757,7 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
 include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -2468,7 +2452,7 @@ include ("inc.header.php");
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_schiffe where id=$shid");
@@ -2508,7 +2492,7 @@ if ($_GET["fu"]==8) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
     include ("inc.header.php");
 
     $eintrag=$_POST["logbuchdaten"];
@@ -2524,10 +2508,10 @@ if ($_GET["fu"]==9) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==10) {
+if ($fuid==10) {
     include ("inc.header.php");
 
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where id=".int_get('pid'));
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];

--- a/inhalt/flotte_delta.php
+++ b/inhalt/flotte_delta.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='flotte_delta';
-$shid=$_GET["shid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'flotte_delta';
+$fuid = int_get('fu');
+$shid = int_get('shid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -113,7 +115,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -133,7 +135,7 @@ if ($_GET["fu"]==2) {
     $max_min1=floor($fracht_min1/2);
     if ($max_min1<$max_bau) {$max_bau=$max_min1;}
     if ($fracht_min2<$max_bau) {$max_bau=$fracht_min2;}
-    $bau=$_POST["bau_auftrag"];
+    $bau=int_post('bau_auftrag');
     if ($max_bau<$bau) {$bau=$max_bau;}
     $projektile=$projektile+$bau;
     $fracht_cantox=$fracht_cantox-($bau*35);
@@ -150,12 +152,12 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad; ?>/aufbau/14.gif'); background-attachment:fixed;" scroll="no" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        if ($_POST["auto"]==1) { 
+        if (int_post('auto')==1) { 
             $auto_projektile=1;$message="<center>".$lang['flottedelta']['autoaktiviert']."</center>";
         } else {
             $auto_projektile=0;$message="<center>".$lang['flottedelta']['autodeaktiviert']."</center>";
@@ -167,7 +169,7 @@ if ($_GET["fu"]==3) {
         echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -221,7 +223,7 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT id,name,ordner FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
@@ -292,7 +294,7 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     $zeiger = @mysql_query("UPDATE $skrupel_schiffe set name=\"".$_POST["schiffname"]."\" where id=$shid and besitzer=$spieler");
     ?>
@@ -305,16 +307,16 @@ if ($_GET["fu"]==6) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set ordner=\"".$_POST["oid"]."\" where ((id=$shid) or ((zielid=$shid) and (flug=4))) and besitzer=$spieler");
+    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set ordner=\"".int_post('oid')."\" where ((id=$shid) or ((zielid=$shid) and (flug=4))) and besitzer=$spieler");
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <br><br><br><br>
         <center><?php echo $lang['flottedelta']['uebernommen']?></center>
         <script language=JavaScript>
-            parent.pfeillinks.window.location='flotte.php?fu=7&oid=<?php echo $_POST["oid"]; ?>&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>';
-            parent.pfeilrechts.window.location='flotte.php?fu=8&oid=<?php echo $_POST["oid"]; ?>&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>';
+            parent.pfeillinks.window.location='flotte.php?fu=7&oid=<?php echo int_post('oid'); ?>&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>';
+            parent.pfeilrechts.window.location='flotte.php?fu=8&oid=<?php echo int_post('oid'); ?>&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>';
             parent.ship.window.location='flotte.php?fu=3&shid=<?php echo $shid; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>';
         </script>
         <?php

--- a/inhalt/flotte_gamma.php
+++ b/inhalt/flotte_gamma.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='flotte_gamma';
-$shid=$_GET["shid"];
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'flotte_gamma';
+$fuid = int_get('fu');
+$shid = int_get('shid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
@@ -62,7 +64,7 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT id,aggro,mission FROM $skrupel_schiffe where id=$shid");
@@ -168,13 +170,13 @@ if ($_GET["fu"]==2) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
 
     if ($module[3]==1) {
-        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".$_POST["aggro"]."\",mission=\"".$_POST["taktik"]."\" where id=$shid and besitzer=$spieler");
+        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".int_post('aggro')."\",mission=\"".int_post('taktik')."\" where id=$shid and besitzer=$spieler");
     } else {
-        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".$_POST["aggro"]."\" where id=$shid and besitzer=$spieler");
+        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".int_post('aggro')."\" where id=$shid and besitzer=$spieler");
     }
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -184,7 +186,7 @@ if ($_GET["fu"]==3) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
@@ -351,7 +353,7 @@ if ($_GET["fu"]==4) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
 
     $zeiger = @mysql_query("SELECT id,aggro,mission FROM $skrupel_schiffe where id=$shid");
@@ -422,13 +424,13 @@ if ($_GET["fu"]==5) {
     include ("inc.footer.php");
 }
 
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
 
     if ($module[3]==1) {
-        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".$_POST["aggro"]."\",mission=\"".$_POST["taktik"]."\" where id=$shid and besitzer=$spieler");
+        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".int_post('aggro')."\",mission=\"".int_post('taktik')."\" where id=$shid and besitzer=$spieler");
     } else {
-        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".$_POST["aggro"]."\" where id=$shid and besitzer=$spieler");
+        $zeiger = @mysql_query("UPDATE $skrupel_schiffe set aggro=\"".int_post('aggro')."\" where id=$shid and besitzer=$spieler");
     }
 
     ?>

--- a/inhalt/galaxie.php
+++ b/inhalt/galaxie.php
@@ -1,19 +1,20 @@
 <?php
 include ('../inc.conf.php');
 //todo das hier ist ne directory traversal lücke und muss weg !!!
-$langfile_1='galaxie';
 $conn = mysql_connect($server.':'.$port, $login, $password);
 $db = mysql_select_db($database, $conn);
 include ('inc.check.php');
 include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'galaxie';
 $fuid = int_get('fu');
 $noani='';
 if (@intval(substr($spieler_optionen,15,1))==1) {
     $noani='_noani';
 }
+
 if ($fuid==1) {
-    $gox = intval($_GET['gox']);
-    $goy = intval($_GET['goy']);
+    $gox = int_get('gox');
+    $goy = int_get('goy');
     $sprung='';
     if (($gox >= 1) and ($goy >= 1)) {
         $gox = round($gox*$umfang/250);
@@ -705,8 +706,8 @@ if ($fuid==2) {
                     }
                 }
                 //////////////////////////////////////////////////////////////////////////////////erste sternenbasis und bildaufbau
-                $gox = intval($_GET['gox']);
-                $goy = intval($_GET['goy']);
+                $gox = int_get('gox');
+                $goy = int_get('goy');
                 if (($gox>=1) and ($goy>=1)) {
                     $start_map_x = $gox;
                     $start_map_y = $goy;

--- a/inhalt/gefecht.php
+++ b/inhalt/gefecht.php
@@ -1,11 +1,15 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='gefecht';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'gefecht';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
-    include ("../inc.conf.php");
+if ($fuid==1) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_kampf where schiff_id_1=$_GET[sh1] and schiff_id_2=$_GET[sh2] and datum=$_GET[datum]");
+    $schiff_id_1=int_get('sh1');
+    $schiff_id_2=int_get('sh2');
+    $datum=int_get('datum');
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_kampf where schiff_id_1=$schiff_id_1 and schiff_id_2=$schiff_id_2 and datum=$datum");
     $gefechteanzahl = @mysql_num_rows($zeiger);
     $array = @mysql_fetch_array($zeiger);
     $id=$array["id"];

--- a/inhalt/hilfe.php
+++ b/inhalt/hilfe.php
@@ -1,8 +1,10 @@
 <?php
-$langfile_1='hilfe';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'hilfe';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]>=1) {
-    include ("../inc.conf.php");
+if ($fuid>=1) {
     include ("inc.header.php");
     
     function tlquad($tl){
@@ -11,14 +13,14 @@ if ($_GET["fu"]>=1) {
     
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-        <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe']['ueberschrift'][$_GET["fu"]]?>';</script>
+        <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe']['ueberschrift'][$fuid]?>';</script>
         <center>
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
                     <td><img src="../bilder/empty.gif" border="0" width="1" height="5"></td>
                 </tr>
                 <tr>
-                    <td style="font-size:12px;"><b><?php echo $lang['hilfe']['ueberschrift'][$_GET["fu"]]?></b></td>
+                    <td style="font-size:12px;"><b><?php echo $lang['hilfe']['ueberschrift'][$fuid]?></b></td>
                 </tr>
                 <tr>
                     <td><img src="../bilder/empty.gif" border="0" width="1" height="7"></td>
@@ -29,12 +31,12 @@ if ($_GET["fu"]>=1) {
             <tr>
                 <td style="color:#aaaaaa;">
                     <?php 
-                    echo $lang['hilfe']['text'][$_GET["fu"]];
+                    echo $lang['hilfe']['text'][$fuid];
 
 
                     //////////////////////////////////////////////////////////////////////////
             
-                    if ($_GET["fu"]==1) {
+                    if ($fuid==1) {
                         echo $lang['hilfe'][$von]['ueberschrift']
                         ?>
                         <table border="0" cellspacing="0" cellpadding="2" width="100%">
@@ -53,7 +55,7 @@ if ($_GET["fu"]>=1) {
                             ?>
                         </table>
                         <?php
-                    } elseif ($_GET["fu"]==2) { 
+                    } elseif ($fuid==2) { 
                         ?>
                         <table border="0" cellspacing="0" cellpadding="2" width="100%">
                             <?php
@@ -71,7 +73,7 @@ if ($_GET["fu"]>=1) {
                             ?>
                         </table>
                         <?php
-                    }elseif ($_GET["fu"]==3) {
+                    }elseif ($fuid==3) {
                         ?>
                         <table border="0" cellspacing="0" cellpadding="2" width="100%">
                             <?php
@@ -88,7 +90,7 @@ if ($_GET["fu"]>=1) {
                             ?>
                         </table>
                         <?php
-                    }elseif ($_GET["fu"]==4) {
+                    }elseif ($fuid==4) {
                         ?>
                         <table border="0" cellspacing="0" cellpadding="2" width="100%">
                             <?php
@@ -105,7 +107,7 @@ if ($_GET["fu"]>=1) {
                             ?>
                         </table>
                         <?php
-                    }elseif ($_GET["fu"]==5) {
+                    }elseif ($fuid==5) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="2">
@@ -125,7 +127,7 @@ if ($_GET["fu"]>=1) {
                             </table>
                         </center>
                         <?php echo $lang['hilfe'][5][1];
-                    }elseif ($_GET["fu"]==6) {
+                    }elseif ($fuid==6) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="2">
@@ -145,8 +147,8 @@ if ($_GET["fu"]>=1) {
                             </table>
                         </center>
                         <?php echo $lang['hilfe'][6][1];
-                    //}elseif ($_GET["fu"]==7) { da unnoetig, nur kopf
-                    }elseif ($_GET["fu"]==8) {
+                    //}elseif ($fuid==7) { da unnoetig, nur kopf
+                    }elseif ($fuid==8) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="2">
@@ -192,8 +194,8 @@ if ($_GET["fu"]>=1) {
                         </center>
                         <?php 
                         echo $lang['hilfe'][8][9];
-                    //}elseif ($_GET["fu"]==9) { da unnoetig, nur kopf
-                    }elseif ($_GET["fu"]==10) {
+                    //}elseif ($fuid==9) { da unnoetig, nur kopf
+                    }elseif ($fuid==10) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="2">
@@ -213,8 +215,8 @@ if ($_GET["fu"]>=1) {
                             </table>
                         </center>
                         <?php
-                    //}elseif ($_GET["fu"]==11) { da unnoetig, nur kopf
-                    }elseif ($_GET["fu"]==12) {
+                    //}elseif ($fuid==11) { da unnoetig, nur kopf
+                    }elseif ($fuid==12) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="0">
@@ -305,8 +307,8 @@ if ($_GET["fu"]>=1) {
                         </center>
                         <center><?php echo $lang['hilfe'][12][9];?></center>
                         <?php
-                    //}elseif ($_GET["fu"]==13 bis 15 ) { unnoetig, nur kopf
-                    }elseif ($_GET["fu"]==16) {
+                    //}elseif ($fuid==13 bis 15 ) { unnoetig, nur kopf
+                    }elseif ($fuid==16) {
                         ?>
                         <ul>
                             <?php
@@ -320,8 +322,8 @@ if ($_GET["fu"]>=1) {
                         </ul>
                         <?php
                         echo $lang['hilfe'][16][2];
-                    //}elseif ($_GET["fu"]==17 bis 32) { unnoetig, nur kopf
-                    }elseif ($_GET["fu"]==33) {
+                    //}elseif ($fuid==17 bis 32) { unnoetig, nur kopf
+                    }elseif ($fuid==33) {
                         ?>
                         <center>
                             <table border="0" cellspacing="0" cellpadding="2">
@@ -370,8 +372,8 @@ if ($_GET["fu"]>=1) {
                             </table>
                         </center>
                         <?php echo $lang['hilfe'][33][0];
-                    }//elseif ($_GET["fu"]==34-47) {}
-                    elseif ($_GET["fu"]==9999) {
+                    }//elseif ($fuid==34-47) {}
+                    elseif ($fuid==9999) {
                         echo 'Sorry, no help found.';
                     }
                     ?>
@@ -382,7 +384,6 @@ if ($_GET["fu"]>=1) {
         //////////////////////////////////////////////////////////////////////////
     include ("inc.footer.php");
 } else {
-    include ("../inc.conf.php");
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -401,7 +402,7 @@ if ($_GET["fu"]>=1) {
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
 
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe.php?fu=<?php if (intval($_GET["fu2"])>=1) {echo $_GET["fu2"];} else {echo "9999";} ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe.php?fu=<?php if (int_get('fu2')>=1) {echo int_get('fu2');} else {echo "9999";} ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
 
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/hilfe_antriebe.php
+++ b/inhalt/hilfe_antriebe.php
@@ -1,19 +1,21 @@
 <?php
-$langfile_1='hilfe_antriebe';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'hilfe_antriebe';
+$fuid = int_get('fu');
 
-if($_GET["fu"]>=1){
-  include ("../inc.conf.php");
+if($fuid>=1){
   include ("inc.header.php");
   ?>
   <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-    <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe_antriebe'][$_GET["fu"]][0]; ?>';</script>
+    <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe_antriebe'][$fuid][0]; ?>';</script>
     <br>
     <table border="0" cellspacing="0" cellpadding="4" width="100%">
       <tr>
         <td colspan="5" style="font-size:18px; font-weight:bold; filter:DropShadow(color=black, offx=2, offy=2)">
           <center>
   <?php
-  echo $lang['hilfe_antriebe'][$_GET["fu"]][0];
+  echo $lang['hilfe_antriebe'][$fuid][0];
   ?>
           </center>
         </td>
@@ -23,7 +25,7 @@ if($_GET["fu"]>=1){
           <br>
           <center>
   <?php
-  echo str_replace('{1}',$lang['hilfe_antriebe'][$_GET["fu"]][1],$lang['hilfe_antriebe']['maxwarp']);
+  echo str_replace('{1}',$lang['hilfe_antriebe'][$fuid][1],$lang['hilfe_antriebe']['maxwarp']);
   ?>
           </center>
         </td>
@@ -31,7 +33,7 @@ if($_GET["fu"]>=1){
       <tr>
         <td style="color:#aaaaaa;"><br>
   <?php
-  echo $lang['hilfe_antriebe'][$_GET["fu"]][2];
+  echo $lang['hilfe_antriebe'][$fuid][2];
   ?>
         </td>
       </tr>
@@ -39,7 +41,6 @@ if($_GET["fu"]>=1){
   <?php
   include ("inc.footer.php");
 }else{
-  include ("../inc.conf.php");
   include ("inc.header.php");
   ?>
 <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -54,7 +55,7 @@ if($_GET["fu"]>=1){
       <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad; ?>" target="_self">
       <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
     </frameset>
-    <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_antriebe.php?fu=<?php echo $_GET["fu2"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+    <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_antriebe.php?fu=<?php echo int_get('fu2'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
     <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
       <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">
       <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/hilfe_native.php
+++ b/inhalt/hilfe_native.php
@@ -1,8 +1,10 @@
 <?php
-$langfile_1='hilfe_native';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'hilfe_native';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]>=1) {
-    include ("../inc.conf.php");
+if ($fuid>=1) {
     include ("inc.header.php");
     
     ?>
@@ -22,13 +24,13 @@ if ($_GET["fu"]>=1) {
 
     for ($i=0;$i<$zaehler;$i++) {
 
-        if ($ur[$i][1]==$_GET["fu"]) {
+        if ($ur[$i][1]==$fuid) {
         ?>
-        <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe_native'][$_GET["fu"]]['name']?>';</script>
+        <script language=JavaScript>parent.document.title='<?php echo $lang['hilfe_native'][$fuid]['name']?>';</script>
         <table border="0" cellspacing="0" cellpadding="4">
             <tr>
                 <td colspan="5" style="font-size:18px; font-weight:bold; filter:DropShadow(color=black, offx=2, offy=2)">
-                    <center><?php echo $lang['hilfe_native'][$_GET["fu"]]['name']?></center>
+                    <center><?php echo $lang['hilfe_native'][$fuid]['name']?></center>
                 </td>
             <tr>
             <tr>
@@ -78,13 +80,13 @@ if ($_GET["fu"]>=1) {
                     <td valign="top" width="100%">
                         <table border="0" cellspacing="0" cellpadding="0" width="100%">
                             <tr>
-                                <td style="color:#aaaaaa;"><?php echo $lang['hilfe_native'][$_GET["fu"]]['beschreibung']; ?></td>
+                                <td style="color:#aaaaaa;"><?php echo $lang['hilfe_native'][$fuid]['beschreibung']; ?></td>
                             </tr>
                             <tr>
                                 <td>&nbsp;</td>
                             </tr>
                             <tr>
-                                <td><center><?php echo $lang['hilfe_native'][$_GET["fu"]]['effekt']; ?></center></td>
+                                <td><center><?php echo $lang['hilfe_native'][$fuid]['effekt']; ?></center></td>
                             </tr>
                          </table>
                         </td>
@@ -95,7 +97,6 @@ if ($_GET["fu"]>=1) {
         }
     include ("inc.footer.php");
 } else {
-    include ("../inc.conf.php");
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -114,7 +115,7 @@ if ($_GET["fu"]>=1) {
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
 
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_native.php?fu=<?php echo $_GET["fu2"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_native.php?fu=<?php echo int_get('fu2'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
 
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/hilfe_osystem.php
+++ b/inhalt/hilfe_osystem.php
@@ -1,33 +1,35 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='orbitale_systeme';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'orbitale_systeme';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]>=1) {
+if ($fuid>=1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
-        <script language=JavaScript>parent.document.title='<?php echo $lang['orbitalesysteme']['name'][$_GET["fu"]]; ?>';</script>
+        <script language=JavaScript>parent.document.title='<?php echo $lang['orbitalesysteme']['name'][$fuid]; ?>';</script>
         <br>
         <table border="0" cellspacing="0" cellpadding="4" width="100%">
             <tr>
                 <td colspan="5" style="font-size:18px; font-weight:bold; filter:DropShadow(color=black, offx=2, offy=2)">
-                    <center><?php echo $lang['orbitalesysteme']['name'][$_GET["fu"]]; ?></center>
+                    <center><?php echo $lang['orbitalesysteme']['name'][$fuid]; ?></center>
                 </td>
             </tr>
             <tr>
                 <td>
                     <table border="0" cellspacing="0" cellpadding="4" width="100%">
                         <tr>
-                            <td><img src="<?php echo $bildpfad; ?>/osysteme/<?php echo $_GET["fu"]; ?>.gif" border="0" width="61" height="64" ></td>
+                            <td><img src="<?php echo $bildpfad; ?>/osysteme/<?php echo $fuid; ?>.gif" border="0" width="61" height="64" ></td>
                             <td>
                                 <table border="0" cellspacing="0" cellpadding="0" width="100%">
                                     <tr>
-                                        <td style="color:#aaaaaa;"><?php echo $lang['orbitalesysteme']['lang'][$_GET["fu"]]; ?></td>
+                                        <td style="color:#aaaaaa;"><?php echo $lang['orbitalesysteme']['lang'][$fuid]; ?></td>
                                     </tr>
                                     <tr>
                                         <td>
                                             <br><br>
-                                            <center><?php echo $lang['orbitalesysteme']['kurz'][$_GET["fu"]]; ?></center>
+                                            <center><?php echo $lang['orbitalesysteme']['kurz'][$fuid]; ?></center>
                                         </td>
                                     </tr>
                                 </table>
@@ -58,7 +60,7 @@ if ($_GET["fu"]>=1) {
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
 
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_osystem.php?fu=<?php echo $_GET["fu2"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_osystem.php?fu=<?php echo int_get('fu2'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
 
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/hilfe_schiff.php
+++ b/inhalt/hilfe_schiff.php
@@ -1,8 +1,10 @@
 <?php
-$langfile_1='hilfe_schiff';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'hilfe_schiff';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]>=1) {
-    include ("../inc.conf.php");
+if ($fuid>=1) {
     include ("inc.header.php");
     ?>
 <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -21,7 +23,7 @@ if ($_GET["fu"]>=1) {
     }
     for ($i=0;$i<$zaehler;$i++) {
         $schiffwert=explode(':',$schiff[$i]);
-        if($schiffwert[1]==$_GET["fu"]) { 
+        if($schiffwert[1]==$fuid) { 
             $fertigkeiten=trim($schiffwert[17]);
             $subpartikel=@intval(substr($fertigkeiten,0,2));
             $terra_warm=@intval(substr($fertigkeiten,5,1));
@@ -358,7 +360,6 @@ if ($_GET["fu"]>=1) {
         }
     include ("inc.footer.php");
 } else {
-    include ("../inc.conf.php");
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -373,7 +374,7 @@ if ($_GET["fu"]>=1) {
                 <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_schiff.php?fu=<?php echo $_GET["fu2"]; ?>&volk=<?php echo $_GET["volk"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_schiff.php?fu=<?php echo int_get('fu2'); ?>&volk=<?php echo $_GET["volk"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/hilfe_spionage.php
+++ b/inhalt/hilfe_spionage.php
@@ -1,9 +1,11 @@
 <?php
-$langfile_1='hilfe_spionage';
-$langfile_2='spionagen';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'hilfe_spionage';
+$langfile_2 = 'spionagen';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]>=1) {
-    include ("../inc.conf.php");
+if ($fuid>=1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">    
@@ -26,7 +28,7 @@ if ($_GET["fu"]>=1) {
             include ("inc.footer.php");
             die();
         }
-        if ($_GET["fu"]==1) { ?>
+        if ($fuid==1) { ?>
             <table border="0" cellspacing="0" cellpadding="4" width="100%">
                 <tr>
                     <td colspan="2" style="font-size:18px; font-weight:bold; filter:DropShadow(color=black, offx=2, offy=2); text-align:center;"><?php echo $lang['hilfe_spionage']['zentrum']?></td>
@@ -48,8 +50,8 @@ if ($_GET["fu"]>=1) {
                 </tr>
             </table>
             <?php
-        }elseif ($_GET["fu"]==2) {
-            $xp = @intval($_GET['spid']);
+        }elseif ($fuid==2) {
+            $xp = int_get('spid');
             $stufe = spionstufe($xp);
             if($stufe > 5) { $lvl = 5; } else { $lvl = $stufe; }
             ?>
@@ -183,8 +185,8 @@ if ($_GET["fu"]>=1) {
                 </tr>
             </table>
             <?php
-        }elseif ($_GET["fu"]==3) {
-            $spionage_id = @intval($_GET['spid']);
+        }elseif ($fuid==3) {
+            $spionage_id = int_get('spid');
             //spionagen
             $file="../daten/unknown/spionagen.txt";
             $fp = @fopen("$file","r");
@@ -275,8 +277,8 @@ if ($_GET["fu"]>=1) {
                 </tr>
             </table>
             <?php
-        }elseif ($_GET["fu"]==4) {
-            $shid = @intval($_GET['spid']);
+        }elseif ($fuid==4) {
+            $shid = int_get('spid');
             $zeiger_schiff = @mysql_query("SELECT * FROM $skrupel_schiffe where besitzer=$spieler and id=$shid");
             $schiff = @mysql_fetch_array($zeiger_schiff);
             $extra = @explode(":", $schiff['extra']);
@@ -378,7 +380,6 @@ if ($_GET["fu"]>=1) {
     include ("inc.footer.php");
 }
 else {
-    include ("../inc.conf.php");
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -393,7 +394,7 @@ else {
                 <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_spionage.php?fu=<?php echo $_GET['fu2']; ?>&spid=<?php echo $_GET['spid']; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_spionage.php?fu=<?php echo int_get('fu2'); ?>&spid=<?php echo int_get('spid'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/kommunikation.php
+++ b/inhalt/kommunikation.php
@@ -3,10 +3,12 @@
 :noTabs=false:indentSize=4:tabSize=4:folding=explicit:collapseFolds=1:
 */
 include ('../inc.conf.php');
-$langfile_1='kommunikation';
-include ('inc.header.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'kommunikation';
 $fuid = int_get('fu');
+
 if ($fuid==1) {
+    include ('inc.header.php');
     ?>
     <script language=javascript>
         function link(url) {
@@ -102,5 +104,5 @@ if ($fuid==1) {
             </table>
         </center>
         <?php
-}
 include ('inc.footer.php');
+}

--- a/inhalt/kommunikation_board.php
+++ b/inhalt/kommunikation_board.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='kommunikation_board';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'kommunikation_board';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <style type="text/css">
@@ -390,9 +392,9 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
-    $forum=$_GET["fo"];
+    $forum=int_get('fo');
     ?>
     <style type="text/css">
         td.forumdunkel {
@@ -651,10 +653,10 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
-    $forum=$_GET["forum"];
+    $forum=int_get('forum');
     $icon=$_POST["icon"];
     include ("inc.check.php");
     $beginner=$spieler_name;
@@ -678,9 +680,9 @@ if ($_GET["fu"]==4) {
     $backlink="kommunikation_board.php?fu=2&uid=$uid&sid=$sid&fo=$forum";
     header ("Location: $backlink");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
-    $forum=$_GET["fo"];
+    $forum=int_get('fo');
     $thema=$_GET["thema"];
     if ($forum==1) { $formname=$lang['kommunikationboard']['offenbarungen'];}
     if ($forum==2) { $formname=$lang['kommunikationboard']['smalltalk'];}
@@ -882,10 +884,10 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
-    $forum=$_GET["forum"];
+    $forum=int_get('forum');
     $thema=$_GET["thema"];
     $icon=$_POST["icon"];
     include ("inc.check.php");

--- a/inhalt/kommunikation_ch.php
+++ b/inhalt/kommunikation_ch.php
@@ -1,9 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='kommunikation_ch';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'kommunikation_ch';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
-    include ("../inc.conf.php");
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" cols="*,360,*">
@@ -16,8 +17,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
-    include ("../inc.conf.php");
+if ($fuid==2) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT chatfarbe, id From $skrupel_user where uid='$uid'");
     $array = @mysql_fetch_array($zeiger);
@@ -134,7 +134,7 @@ if ($_GET["fu"]==2) {
         $nachricht=parsetext($nachricht);
         $jetzt=date("H:i",$aktuell);
          //$text="<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\"><tr><td valign=\"top\" style=\"color:$farbe;\"><nobr>$spieler_name&nbsp;</nobr></td><td valign=\"top\" style=\"color:#aaaaaa;\"><nobr>@ $jetzt&nbsp;</nobr></td><td valign=\"top\">$nachricht</td></tr></table>";
-        $an=$_POST["an"];
+        $an=int_post('an');
         $zeiger = @mysql_query("INSERT INTO $skrupel_chat (spiel,datum,text,an,von,farbe) values ($spiel,'$aktuell','$nachricht','$an','$spieler_name','$farbe');");
     }
     if (strlen($_GET["zeit"])>=1) {
@@ -173,7 +173,7 @@ if ($_GET["fu"]==2) {
     } else { 
         $neuzeit=time();$first=1;
     }
-    $akt=$_POST["akt"];
+    $akt=int_post('akt');
     if (!$akt) {$akt=10;}
     ?>
     <script language="Javascript">
@@ -291,7 +291,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT chatfarbe, id From $skrupel_user where uid='$uid'");
     $array = @mysql_fetch_array($zeiger);

--- a/inhalt/kommunikation_exch.php
+++ b/inhalt/kommunikation_exch.php
@@ -1,13 +1,15 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='kommunikation_exch';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'kommunikation_exch';
+$fuid = int_get('fu');
 $uid=$_GET["uid"];
 $sid=$_GET["sid"];
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
-    if(!$_POST["scroll_lock"]){$_POST["scroll_lock"]=0;}
+    //if(!$_POST["scroll_lock"]){$_POST["scroll_lock"]=0;}
     include ("inc.check.php"); ?>
     <html>
         <head>
@@ -67,7 +69,7 @@ if ($_GET["fu"]==1) {
     <?php
     @mysql_close();
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     ?>
     <html>
         <head>
@@ -87,7 +89,7 @@ if ($_GET["fu"]==2) {
     </html>
     <?php
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $zeiger = @mysql_query("SELECT chatfarbe, id From $skrupel_user where uid='$uid'");
@@ -233,7 +235,7 @@ if ($_GET["fu"]==3) {
                 $nachricht=parsetext($nachricht);
                 $jetzt=date("H:i",$aktuell);
                 //$text="<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\"><tr><td valign=\"top\" style=\"color:$farbe;\"><nobr>$spieler_name&nbsp;</nobr></td><td valign=\"top\" style=\"color:#aaaaaa;\"><nobr>@ $jetzt&nbsp;</nobr></td><td valign=\"top\">$nachricht</td></tr></table>";
-                $an=$_POST["an"];
+                $an=int_post('an');
                 $zeiger = @mysql_query("INSERT INTO $skrupel_chat (spiel,datum,text,an,von,farbe) values (1,'$aktuell','$nachricht','$an','$spieler_name','$farbe');");
             }
             if (strlen($_GET["zeit"])>=1) { } else { $neuzeit=time();$first=1;}
@@ -297,7 +299,7 @@ if ($_GET["fu"]==3) {
     <?php
     @mysql_close();
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $zeiger = @mysql_query("SELECT chatfarbe, id From $skrupel_user where uid='$uid'");
@@ -367,7 +369,7 @@ if ($_GET["fu"]==4) {
     <?php
     @mysql_close();
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $zeiger = @mysql_query("SELECT chatfarbe, id From $skrupel_user where uid='$uid'");
@@ -477,7 +479,7 @@ if ($_GET["fu"]==5) {
     <?php
     @mysql_close();
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     include ("inc.check.php");
@@ -573,7 +575,7 @@ if ($_GET["fu"]==6) {
                                 $user_id=$array["id"];
                                 $spielerchatfarbe=$array["chatfarbe"];
                                 ?>
-                                <option value="<?php echo $user_id; ?>" style="background-color:#<?php echo $spielerchatfarbe?>;color:#000000" <?php if($_POST["an"]==$user_id) echo "selected";?> ><?php echo $nick?></option>
+                                <option value="<?php echo $user_id; ?>" style="background-color:#<?php echo $spielerchatfarbe?>;color:#000000" <?php if(int_post('an')==$user_id) echo "selected";?> ><?php echo $nick?></option>
                                 <?php
                             }
                             ?>
@@ -603,7 +605,7 @@ if ($_GET["fu"]==6) {
     </html>
     <?php @mysql_close();
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
 ?>
 <html>
 <head>

--- a/inhalt/kommunikation_politik.php
+++ b/inhalt/kommunikation_politik.php
@@ -1,9 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='kommunikation_politik';
-
+include ('../inc.conf.php');
 include_once ('inc.hilfsfunktionen.php');
-if ($_GET["fu"]==1) {
+$langfile_1 = 'kommunikation_politik';
+$fuid = int_get('fu');
+
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" cols="50%,50%">
@@ -14,7 +15,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -166,7 +167,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -268,10 +269,10 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
-    $art=$_POST["art"];
-    $spielernummer=$_POST["spielernummer"];
+    $art = int_post('art');
+    $spielernummer = int_post('spielernummer');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
@@ -522,10 +523,10 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
-    $art=$_POST["art"];
-    $spielernummer=$_POST["spieler2"];
+    $art = int_post('art');
+    $spielernummer = int_post('spieler2');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
@@ -536,7 +537,7 @@ if ($_GET["fu"]==5) {
     $spieler2sprache=($sprachtemp_2["sprache"]=='')?$language:$sprachtemp_2["sprache"];
     $file="../lang/".$spieler2sprache."/lang.kommunikation_politik_b.php";
     include($file);
-    $anfrage_id=$_GET["anf"];
+    $anfrage_id=int_get('anf');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_politik_anfrage where partei_a=$spieler and spiel=$spiel and id=$anfrage_id");
     $anzahl = @mysql_num_rows($zeiger);
     if ($anzahl==1) {
@@ -633,10 +634,10 @@ if ($_GET["fu"]==5) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
-    $art=$_POST["art"];
-    $spielernummer=$_POST["spieler2"];
+    $art = int_post('art');
+    $spielernummer = int_post('spieler2');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
@@ -647,7 +648,7 @@ if ($_GET["fu"]==6) {
     $spieler2sprache=($sprachtemp_2["sprache"]=='')?$language:$sprachtemp_2["sprache"];
     $file="../lang/".$spieler2sprache."/lang.kommunikation_politik_b.php";
     include($file);
-    $anfrage_id=$_GET["anf"];
+    $anfrage_id=int_get('anf');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_politik_anfrage where partei_a=$spieler and spiel=$spiel and id=$anfrage_id");
     $anzahl = @mysql_num_rows($zeiger);
     if ($anzahl==1) {

--- a/inhalt/kommunikation_subfunk.php
+++ b/inhalt/kommunikation_subfunk.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='kommunikation_subfunk';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'kommunikation_subfunk';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -64,7 +66,7 @@ if ($_GET["fu"]==1) {
                                             if ($zahl>=1) {
                                                 for ($n=0;$n<$zahl;$n++) {
                                                     ?>
-                                                    <option value="<?php echo $feind[$n][2]; ?>" style="background-color:<?php echo $feind[$n][1]; ?>;" <?php if ($_GET["an"]==$feind[$n][2]) { echo "selected"; } ?>><?php echo $feind[$n][0]; ?></option>
+                                                    <option value="<?php echo $feind[$n][2]; ?>" style="background-color:<?php echo $feind[$n][1]; ?>;" <?php if (int_get('an')==$feind[$n][2]) { echo "selected"; } ?>><?php echo $feind[$n][0]; ?></option>
                                                     <?php
                                                 }
                                             }
@@ -113,10 +115,10 @@ if ($_GET["fu"]==1) {
     include ("inc.footer.php");
     @mysql_close();
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
-    $spielernummer=$_POST["empfang"];
+    $spielernummer=int_post('empfang');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
@@ -231,10 +233,10 @@ if ($_GET["fu"]==2) {
     $nachricht=str_replace("::::::", ":::::",$nachricht);
     $nachricht=parsetext($nachricht);
     $nachricht_org=$nachricht;
-    if ($_POST["empfang"]>=1) {
+    if (int_post('empfang')>=1) {
         $nachricht=str_replace(array('{1}','{2}','{3}'),array($spielerfarbe[$spieler], $spieler_name, $nachricht),$spieler."::::::".$lang['kommunikationsubfunk_b']['nachricht']);
         $datum=time();
-        $zeiger_temp = @mysql_query("insert into $skrupel_neuigkeiten (datum,art,icon,inhalt,spieler_id,spiel_id,sicher) values ('$datum',7,'../bilder/news/subfunk.jpg','$nachricht',".$_POST["empfang"].",$spiel,1);");
+        $zeiger_temp = @mysql_query("insert into $skrupel_neuigkeiten (datum,art,icon,inhalt,spieler_id,spiel_id,sicher) values ('$datum',7,'../bilder/news/subfunk.jpg','$nachricht',".int_post('empfang').",$spiel,1);");
         ?>
         <center>
             <table border="0" cellspacing="0" cellpadding="0" height="100%">
@@ -284,7 +286,7 @@ if ($_GET["fu"]==2) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ?>
     <frameset framespacing="0" border="false" frameborder="0" rows="18,*,16">
@@ -299,7 +301,7 @@ if ($_GET["fu"]==3) {
                 <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="kommunikation_subfunk.php?fu=4&emp=<?php echo $_GET["emp"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="kommunikation_subfunk.php?fu=4&emp=<?php echo int_get('emp'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad; ?>" target="_self">
@@ -317,8 +319,7 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
-    include ("../inc.conf.php");
+if ($fuid==4) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" scroll="no" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -330,7 +331,7 @@ if ($_GET["fu"]==4) {
                 <td></td>
             </tr>
             <tr>
-                <td><form name="formular" method="post" action="kommunikation_subfunk.php?fu=5&emp=<?php echo $_GET["emp"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>"></td>
+                <td><form name="formular" method="post" action="kommunikation_subfunk.php?fu=5&emp=<?php echo int_get('emp'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>"></td>
                 <td><img src="../bilder/empty.gif" width="1" height="2"></td>
                 <td></td>
             </tr>
@@ -358,11 +359,11 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
-    $spielernummer=$_POST["empfang"];
+    $spielernummer=int_post('empfang');
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
@@ -477,7 +478,7 @@ if ($_GET["fu"]==5) {
         $nachricht=parsetext($nachricht);
         $nachricht=str_replace(array('{1}','{2}','{3}'),array($spielerfarbe[$spieler], $spieler_name, $nachricht),$spieler."::::::".$lang['kommunikationsubfunk_b']['nachricht']);
         $datum=time();
-        $zeiger_temp = @mysql_query("insert into $skrupel_neuigkeiten (datum,art,icon,inhalt,spieler_id,spiel_id,sicher) values ('$datum',7,'../bilder/news/subfunk.jpg','$nachricht',".$_GET["emp"].",$spiel,1);");
+        $zeiger_temp = @mysql_query("insert into $skrupel_neuigkeiten (datum,art,icon,inhalt,spieler_id,spiel_id,sicher) values ('$datum',7,'../bilder/news/subfunk.jpg','$nachricht',".$int_get('emp').",$spiel,1);");
         ?>
         <center>
             <table border="0" cellspacing="0" cellpadding="0" height="100%">

--- a/inhalt/menu.php
+++ b/inhalt/menu.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='menu';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'menu';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>
@@ -84,7 +86,7 @@ if ($_GET["fu"]==1) {
         </form>
     <?php include ("inc.footer.php"); 
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>

--- a/inhalt/meta.php
+++ b/inhalt/meta.php
@@ -1,8 +1,10 @@
 <?php
-$langfile_1='meta';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
-    include ("../inc.conf.php");
+if ($fuid==1) {
     include ("inc.header.php");
         ?>
         <body text="#000000" bgcolor="#444444" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/meta_aufgabe.php
+++ b/inhalt/meta_aufgabe.php
@@ -1,9 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_aufgabe';
+include ('../inc.conf.php');
 include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_aufgabe';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -57,7 +58,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -74,9 +75,8 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.host_func.php");
-    include ("../inc.conf.php");
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     include ("inc.check.php");

--- a/inhalt/meta_fordner.php
+++ b/inhalt/meta_fordner.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_fordner';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_fordner';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -153,7 +155,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -168,12 +170,12 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $ooid=$_GET["ooid"];
+        $ooid=int_get('ooid');
         $ordnerneu=$_POST["ordnerneu"];
         $ordnerneu=addslashes($ordnerneu);
         $zeiger_temp = @mysql_query("UPDATE $skrupel_ordner set name='$ordnerneu' where id =$ooid");
@@ -184,12 +186,12 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $ooid=$_GET["ooid"];
+        $ooid=int_get('ooid');
         $zeiger_temp = @mysql_query("DELETE FROM $skrupel_ordner where id =$ooid");
         $zeiger_temp = @mysql_query("UPDATE $skrupel_schiffe set ordner=0 where ordner=$ooid");
         ?>
@@ -199,12 +201,12 @@ if ($_GET["fu"]==4) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $ooid=$_GET["ooid"];
+        $ooid=int_get('ooid');
         $icon=$_POST["icon"];
         $zeiger_temp = @mysql_query("UPDATE $skrupel_ordner set icon='$icon' where id =$ooid");
         ?>

--- a/inhalt/meta_optionen.php
+++ b/inhalt/meta_optionen.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_optionen';
-include ("../lang/sprachen.php");
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+include ('../lang/sprachen.php');
+$langfile_1 = 'meta_optionen';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT sprache, optionen, email, icq, jabber, avatar, chatfarbe From $skrupel_user where uid='$uid'");
     $array = @mysql_fetch_array($zeiger);
@@ -267,7 +269,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -282,24 +284,24 @@ if ($_GET["fu"]==2) {
         $passwortneu='';
         $passwortneu=$_POST['passwortneu'];
         $optionen='';
-        if ($_POST['email_nach']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['icq_nach']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_kol']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_min']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_vorrat']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_cantox']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_logbuch']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_schiff_tank']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_schiff_fracht']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_schiff_spezial']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_schiff_logbuch']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_i']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_ii']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_iii']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['tool_schiff_bild']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_iiii']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_iiiii']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
-        if ($_POST['feature_iiiiii']==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('email_nach')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('icq_nach')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_kol')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_min')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_vorrat')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_cantox')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_logbuch')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_schiff_tank')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_schiff_fracht')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_schiff_spezial')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_schiff_logbuch')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_i')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_ii')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_iii')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('tool_schiff_bild')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_iiii')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_iiiii')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
+        if (int_post('feature_iiiiii')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
         $zeiger_temp = @mysql_query("UPDATE $skrupel_user set jabber='$jabber', email='$email', icq='$icq', optionen='$optionen', chatfarbe='$chatfarbe', avatar='$avatar', sprache='$sprache' where uid='$uid'");
         if (strlen($passwortneu)>=1) {
             $zeiger_temp = @mysql_query("UPDATE $skrupel_user set passwort='$passwortneu' where uid='$uid'");

--- a/inhalt/meta_pklassen.php
+++ b/inhalt/meta_pklassen.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_pklassen';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_pklassen';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/meta_rassen.php
+++ b/inhalt/meta_rassen.php
@@ -1,9 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_rassen';
-$langfile_2='orbitale_systeme';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_rassen';
+$langfile_2 = 'orbitale_systeme';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <script type="text/javascript">
@@ -48,7 +50,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     $rasse=$_GET["rasse"];
     if ((!strstr($rasse, '.')) and (!strstr($rasse, '/'))) {

--- a/inhalt/meta_simulation.php
+++ b/inhalt/meta_simulation.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_simulation';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_simulation';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ///////////////////////////////////////////////////////////////////////////////////////////////RASSENEIGENSCHAFTEN ANFANG
     $daten_verzeichnis=$main_verzeichnis."../daten/";
@@ -297,7 +299,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ///////////////////////////////////////////////////////////////////////////////////////////////SCHIFFE ANFANG
     $daten_verzeichnis=$main_verzeichnis."../daten/";
@@ -1950,7 +1952,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ///////////////////////////////////////////////////////////////////////////////////////////////SCHIFFE ANFANG
     $daten_verzeichnis=$main_verzeichnis."../daten/";

--- a/inhalt/meta_spezien.php
+++ b/inhalt/meta_spezien.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='meta_spezien';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'meta_spezien';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/osys_spionage.php
+++ b/inhalt/osys_spionage.php
@@ -1,6 +1,9 @@
 <?php
-include("../inc.conf.php");
-$langfile_1='osys_spionage';
+include('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'osys_spionage';
+$fuid = int_get('fu');
+$pid = int_get('fu');
 
 include("inc.header.php");
 $schiffdatei = false;
@@ -47,7 +50,7 @@ if(!$schiffdatei) {
     die();
 }
 //spion bzw auswahl an spionen anzeigen
-if($_GET["fu"] == 1) {
+if ($fuid==1) {
     ?>
     <body text="#000000" scroll="auto" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <script language=JavaScript>
@@ -63,7 +66,7 @@ if($_GET["fu"] == 1) {
             }
         </script>
         <?php
-        $zeiger_planet = @mysql_query("SELECT id,cantox,besitzer,min1,min2,min3,x_pos,y_pos,sternenbasis,sternenbasis_id FROM $skrupel_planeten where besitzer=$spieler and id=".@intval($_GET['pid']));
+        $zeiger_planet = @mysql_query("SELECT id,cantox,besitzer,min1,min2,min3,x_pos,y_pos,sternenbasis,sternenbasis_id FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $planet = @mysql_fetch_array($zeiger_planet);
         $zeiger_schiff = @mysql_query("SELECT id,name,klasse,volk,tarnfeld,bild_gross,ordner FROM $skrupel_schiffe where spiel=$spiel and besitzer=$spieler and volk='unknown' and klasseid=1 and s_x=".$planet['x_pos']." and s_y=".$planet['y_pos']);
         if(@mysql_num_rows($zeiger_schiff) == 0) {
@@ -213,7 +216,7 @@ if($_GET["fu"] == 1) {
             <?php
         }
 }
-if($_GET["fu"] == 2) {
+if ($fuid==2) {
     ?>
     <body text="#000000" scroll="auto" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <script language="JavaScript">
@@ -234,8 +237,8 @@ if($_GET["fu"] == 2) {
                 </tr>
                 <tr>
                     <td>
-                        <form name="formular"  method="post" action="osys_spionage.php?fu=3&pid=<?php echo $_GET['pid'];?>&uid=<?php echo $uid;?>&sid=<?php echo $sid;?>" onSubmit="return check();">
-                        <input type="hidden" name="stufe" value="<?php echo $_POST['stufe'];?>">
+                        <form name="formular"  method="post" action="osys_spionage.php?fu=3&pid=<?php echo $pid;?>&uid=<?php echo $uid;?>&sid=<?php echo $sid;?>" onSubmit="return check();">
+                        <input type="hidden" name="stufe" value="<?php echo int_post('stufe');?>">
                     </td>
                     <td><?php echo $lang['osys']['spionage']['Schiffsname']?></td>
                     <td></td>
@@ -263,11 +266,11 @@ if($_GET["fu"] == 2) {
         </script>
         <?php
 }
-if($_GET["fu"] == 3) {
+if ($fuid==3) {
     ?>
     <body text="#000000" scroll="auto" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $zeiger_planet = @mysql_query("SELECT id,cantox,besitzer,min1,min2,min3,x_pos,y_pos,sternenbasis,sternenbasis_id FROM $skrupel_planeten where besitzer=$spieler and id=".@intval($_GET['pid']));
+        $zeiger_planet = @mysql_query("SELECT id,cantox,besitzer,min1,min2,min3,x_pos,y_pos,sternenbasis,sternenbasis_id FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $planet = @mysql_fetch_array($zeiger_planet);
         $zeiger_schiff = @mysql_query("SELECT id FROM $skrupel_schiffe where spiel=$spiel and besitzer=$spieler and volk='unknown' and klasseid=1 and s_x=".$planet['x_pos']." and s_y=".$planet['y_pos']);
         if($zug_abgeschlossen==0 && @mysql_num_rows($zeiger_schiff) == 0) {
@@ -312,7 +315,7 @@ if($_GET["fu"] == 3) {
                 <br>
                 <?php
             }else {
-                $si = $_POST['stufe'];
+                $si = int_post('stufe');
                 if($spion_daten[$si]['cantox']<=$planet['cantox'] && $spion_daten[$si]['min1']<=$planet['min1'] && $spion_daten[$si]['min2']<=$planet['min2'] && $spion_daten[$si]['min3']<=$planet['min3']) { $ok=1; } else { $ok=0; };
                 if($ok) {
                     $cantox = $planet['cantox'] - $spion_daten[$si]['cantox'];

--- a/inhalt/planeten.php
+++ b/inhalt/planeten.php
@@ -1,8 +1,11 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='planeten';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'planeten';
+$fuid = int_get('fu');
+$pid = int_get('pid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <script language=JavaScript>
@@ -130,20 +133,21 @@ if ($_GET["fu"]==1) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
+    $pid = int_get('pid');
     ?>
     <frameset framespacing="0" border="false" frameborder="0" cols="*,26,270,208,400,26,*">
         <frame name="randlinks" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=14&bildpfad=<?php echo $bildpfad?>" target="_self">
-        <frame name="pfeillinks" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=6&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
-        <frame name="planeten" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=3&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="pfeillinks" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=6&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="planeten" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=3&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
         <?php if ($zug_abgeschlossen==0) { ?>
-        <frame name="planetenmenu" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=4&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="planetenmenu" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=4&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
         <?php } else { ?>
-        <frame name="planetenmenu" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=5&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="planetenmenu" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=5&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
         <?php } ?>
-        <frame name="planetendetails" scrolling="auto" marginwidth="0" marginheight="0" noresize src="planeten_alpha.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
-        <frame name="pfeilrechts" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=7&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="planetendetails" scrolling="auto" marginwidth="0" marginheight="0" noresize src="planeten_alpha.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
+        <frame name="pfeilrechts" scrolling="no" marginwidth="0" marginheight="0" noresize src="planeten.php?fu=7&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" target="_self">
         <frame name="randrechts" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=14&bildpfad=<?php echo $bildpfad?>" target="_self">
     </frameset>
     <noframes>
@@ -151,10 +155,9 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
-    include ("../inc.conf.php");
+if ($fuid==3) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];
@@ -344,8 +347,9 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
+    $pid = int_get('pid');
     ?>
     <script language=JavaScript>
         function linksub(url) {
@@ -362,21 +366,22 @@ if ($_GET["fu"]==4) {
             </tr>
         </table>
         <map name="konsole">
-            <area shape=rect coords="26,15,52,40" href="javascript:linksub('planeten_alpha.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['details']?>">
-            <area shape=rect coords="74,15,97,40" href="javascript:linksub('planeten_alpha.php?fu=4&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['globalesysteme']?>">
-            <area shape=rect coords="120,15,143,40" href="javascript:linksub('planeten_alpha.php?fu=2&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['sternenbasis']?>">
-            <area shape=rect coords="69,62,103,86" href="javascript:linksub('planeten_beta.php?fu=2&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['logbuch']?>">
-            <area shape=rect coords="26,58,53,84" href="javascript:linksub('planeten_beta.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['dominantespezies']?>">
-            <area shape=rect coords="120,62,143,86" href="javascript:linksub('planeten_beta.php?fu=4&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['schiffe']?>">
-            <area shape=rect coords="163,11,184,33" href="javascript:linksub('planeten_gamma.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['minen']?>">
-            <area shape=rect coords="163,40,184,60" href="javascript:linksub('planeten_gamma.php?fu=4&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['fabriken']?>">
-            <area shape=rect coords="163,65,184,87" href="javascript:linksub('planeten_gamma.php?fu=9&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['pds']?>">
+            <area shape=rect coords="26,15,52,40" href="javascript:linksub('planeten_alpha.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['details']?>">
+            <area shape=rect coords="74,15,97,40" href="javascript:linksub('planeten_alpha.php?fu=4&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['globalesysteme']?>">
+            <area shape=rect coords="120,15,143,40" href="javascript:linksub('planeten_alpha.php?fu=2&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['sternenbasis']?>">
+            <area shape=rect coords="69,62,103,86" href="javascript:linksub('planeten_beta.php?fu=2&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['logbuch']?>">
+            <area shape=rect coords="26,58,53,84" href="javascript:linksub('planeten_beta.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['dominantespezies']?>">
+            <area shape=rect coords="120,62,143,86" href="javascript:linksub('planeten_beta.php?fu=4&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['schiffe']?>">
+            <area shape=rect coords="163,11,184,33" href="javascript:linksub('planeten_gamma.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['minen']?>">
+            <area shape=rect coords="163,40,184,60" href="javascript:linksub('planeten_gamma.php?fu=4&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['fabriken']?>">
+            <area shape=rect coords="163,65,184,87" href="javascript:linksub('planeten_gamma.php?fu=9&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['pds']?>">
         </map>
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
+    $pid = int_get('pid');
     ?>
     <script language=JavaScript>
         function linksub(url) {
@@ -393,17 +398,16 @@ if ($_GET["fu"]==5) {
             </tr>
         </table>
         <map name="konsole">
-            <area shape=rect coords="26,15,52,40" href="javascript:linksub('planeten_alpha.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['details']?>">
-            <area shape=rect coords="69,62,103,86" href="javascript:linksub('planeten_beta.php?fu=2&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['logbuch']?>">
-            <area shape=rect coords="26,58,53,84" href="javascript:linksub('planeten_beta.php?fu=1&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['dominantespezies']?>">
-            <area shape=rect coords="120,62,143,86" href="javascript:linksub('planeten_beta.php?fu=4&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['schiffe']?>">
+            <area shape=rect coords="26,15,52,40" href="javascript:linksub('planeten_alpha.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['details']?>">
+            <area shape=rect coords="69,62,103,86" href="javascript:linksub('planeten_beta.php?fu=2&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['logbuch']?>">
+            <area shape=rect coords="26,58,53,84" href="javascript:linksub('planeten_beta.php?fu=1&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['dominantespezies']?>">
+            <area shape=rect coords="120,62,143,86" href="javascript:linksub('planeten_beta.php?fu=4&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>');self.focus();" title="<?php echo $lang['planeten']['schiffe']?>">
         </map>
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
-    $pid=$_GET["pid"];
     ?>
     <script language=JavaScript>
         function linksub(url) {
@@ -436,9 +440,8 @@ if ($_GET["fu"]==6) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
-    $pid=$_GET["pid"];
     ?>
     <script language=JavaScript>
     function linksub(url) {

--- a/inhalt/planeten_alpha.php
+++ b/inhalt/planeten_alpha.php
@@ -1,11 +1,14 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='planeten_alpha';
-$langfile_2='orbitale_systeme';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'planeten_alpha';
+$langfile_2 = 'orbitale_systeme';
+$fuid = int_get('fu');
+$pid = int_get('pid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];
@@ -115,12 +118,12 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" scroll="auto" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $cantox=$array["cantox"];
@@ -264,13 +267,13 @@ if ($_GET["fu"]==2) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
-    $art=$_GET["art"];
+    $art=int_get('art');
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $x_pos=$array["x_pos"];
@@ -371,7 +374,7 @@ if ($_GET["fu"]==3) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
     $file='../daten/orbitale_systeme.txt';
     $fp = @fopen("$file","r");
@@ -387,7 +390,7 @@ if ($_GET["fu"]==4) {
         }
         @fclose($fp);
     }
-    $zeiger = @mysql_query("SELECT id,besitzer,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT id,besitzer,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $osys_anzahl=$array["osys_anzahl"];
@@ -452,8 +455,9 @@ if ($_GET["fu"]==4) {
         </center>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
+    $oid = int_get('oid');
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <center>
@@ -462,30 +466,30 @@ if ($_GET["fu"]==5) {
                     <td><img src="../bilder/empty.gif" border="0" width="1" height="5"></td>
                 </tr>
                 <tr>
-                    <td><center><?php echo $lang['orbitalesysteme']['name'][$_GET['oid']]?></center></td>
+                    <td><center><?php echo $lang['orbitalesysteme']['name'][$oid]?></center></td>
                 </tr>
             </table>
         </center>
         <center>
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td><img src="<?php echo $bildpfad?>/osysteme/<?php echo $_GET['oid']?>.gif" border="0" width="61" height="64" title="<?php echo $osys_daten[$_GET['oid']][0]?>"></td>
-                    <td style="color:#aaaaaa;"><?php echo $lang['orbitalesysteme']['lang'][$_GET['oid']]?></td>
+                    <td><img src="<?php echo $bildpfad?>/osysteme/<?php echo $oid?>.gif" border="0" width="61" height="64" title="<?php echo $osys_daten[$oid][0]?>"></td>
+                    <td style="color:#aaaaaa;"><?php echo $lang['orbitalesysteme']['lang'][$oid]?></td>
                 </tr>
             </table>
         </center>
         <center>
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td><?php echo $lang['orbitalesysteme']['kurz'][$_GET['oid']]?></td>
+                    <td><?php echo $lang['orbitalesysteme']['kurz'][$oid]?></td>
                 </tr>
             </table>
         </center>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
-    $zeiger2 = @mysql_query("SELECT id,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger2 = @mysql_query("SELECT id,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array2 = @mysql_fetch_array($zeiger2);
     $spiel=$array2["spiel"];
     $cantox=$array2["cantox"];
@@ -593,9 +597,9 @@ if ($_GET["fu"]==6) {
                     <tr>
                         <td><img src="../bilder/empty.gif" border="0" width="1" height="18"></td>
                         <td>
-                            <form name="formular" method="post" action="planeten_alpha.php?fu=7&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>">
+                            <form name="formular" method="post" action="planeten_alpha.php?fu=7&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>">
                             <input type="hidden" name="bau" value="<?php echo $nj?>">
-                            <input type="hidden" name="position" value="<?php echo $_GET["position"]?>">
+                            <input type="hidden" name="position" value="<?php echo int_get('position')?>">
                         </td>
                         <td><nobr><a href="javascript:systemdetail(<?php echo $nj?>);" style="color:#ffffff;"><?php echo $lang['orbitalesysteme']['name'][$nj]?></a></nobr></td>
                         <td style="color:#<?php if ($cantox>=$osys_daten[$nj][1]) { ?>aaaaaa<?php } else { ?>ff0000<?php } ?>;"><center><?php echo $osys_daten[$nj][1]?></center></td>
@@ -630,9 +634,9 @@ if ($_GET["fu"]==6) {
         </center>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
-    $zeiger2 = @mysql_query("SELECT id,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger2 = @mysql_query("SELECT id,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_anzahl,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array2 = @mysql_fetch_array($zeiger2);
     $spiel=$array2["spiel"];
     $cantox=$array2["cantox"];
@@ -706,42 +710,44 @@ if ($_GET["fu"]==7) {
         $osys_daten[4][6]=floor(pow(96,($num_spio_osys*0.08)+1)); //vom
         $reihenfolge[]=4;
     }
-    $osys_benoetigt[0]=$lang['orbitalesysteme']['name'][$_POST["bau"]];
-    $osys_benoetigt[1]=$osys_daten[$_POST["bau"]][1];
-    $osys_benoetigt[2]=$osys_daten[$_POST["bau"]][2];
-    $osys_benoetigt[3]=$osys_daten[$_POST["bau"]][3];
-    $osys_benoetigt[4]=$osys_daten[$_POST["bau"]][4];
-    $osys_benoetigt[5]=$osys_daten[$_POST["bau"]][5];
-    $osys_benoetigt[6]=$osys_daten[$_POST["bau"]][6];
-    if (($osys_1==$_POST["bau"]) or ($osys_2==$_POST["bau"]) or ($osys_3==$_POST["bau"]) or ($osys_4==$_POST["bau"]) or ($osys_5==$_POST["bau"]) or ($osys_6==$_POST["bau"]) or (!$lang['orbitalesysteme']['name'][$_POST["bau"]]>=1)) {
+    $bau = int_post('bau');
+    $position = int_post('position');
+    $osys_benoetigt[0]=$lang['orbitalesysteme']['name'][$bau];
+    $osys_benoetigt[1]=$osys_daten[$bau][1];
+    $osys_benoetigt[2]=$osys_daten[$bau][2];
+    $osys_benoetigt[3]=$osys_daten[$bau][3];
+    $osys_benoetigt[4]=$osys_daten[$bau][4];
+    $osys_benoetigt[5]=$osys_daten[$bau][5];
+    $osys_benoetigt[6]=$osys_daten[$bau][6];
+    if (($osys_1==$bau) or ($osys_2==$bau) or ($osys_3==$bau) or ($osys_4==$bau) or ($osys_5==$bau) or ($osys_6==$bau) or (!$lang['orbitalesysteme']['name'][$bau]>=1)) {
     } else {
         if (($vorrat>=$osys_benoetigt[2]) and ($cantox>=$osys_benoetigt[1]) and ($min1>=$osys_benoetigt[4]) and ($min2>=$osys_benoetigt[5]) and ($min3>=$osys_benoetigt[6]) and ($lemin>=$osys_benoetigt[3])) {
-            if($zug_abgeschlossen==0 && $_POST["position"]<=$osys_anzahl) {
+            if($zug_abgeschlossen==0 && $position<=$osys_anzahl) {
                 $vorrat=$vorrat-$osys_benoetigt[2];
                 $cantox=$cantox-$osys_benoetigt[1];
                 $min1=$min1-$osys_benoetigt[4];
                 $min2=$min2-$osys_benoetigt[5];
                 $min3=$min3-$osys_benoetigt[6];
                 $lemin=$lemin-$osys_benoetigt[3];
-                if ($_POST["position"]==1) {
+                if ($position==1) {
                     $spalte="osys_1";
-                }elseif ($_POST["position"]==2) {
+                }elseif ($position==2) {
                     $spalte="osys_2";
-                }elseif ($_POST["position"]==3) {
+                }elseif ($position==3) {
                     $spalte="osys_3";
-                }elseif ($_POST["position"]==4) {
+                }elseif ($position==4) {
                     $spalte="osys_4";
-                }elseif ($_POST["position"]==5) {
+                }elseif ($position==5) {
                     $spalte="osys_5";
-                }elseif ($_POST["position"]==6) {
+                }elseif ($position==6) {
                     $spalte="osys_6";
                 }
-                $art=$_POST["bau"];
+                $art=$bau;
                 if($art==24){
                     $osys_anzahl=min($osys_anzahl+2,6);
-                    $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set osys_anzahl=$osys_anzahl where besitzer=$spieler and id=".$_GET["pid"]);
+                    $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set osys_anzahl=$osys_anzahl where besitzer=$spieler and id=".$pid);
                 }
-                $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set $spalte=$art,cantox=$cantox,min1=$min1,min2=$min2,min3=$min3,lemin=$lemin,vorrat=$vorrat where besitzer=$spieler and id=".$_GET["pid"]);
+                $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set $spalte=$art,cantox=$cantox,min1=$min1,min2=$min2,min3=$min3,lemin=$lemin,vorrat=$vorrat where besitzer=$spieler and id=".$pid);
                 $message="<center>".str_replace(array('{1}'),array($osys_benoetigt[0]),$lang['planetenalpha']['erfolgreichkonstruiert'])."</center>";
             }else { 
                 $message="";
@@ -769,9 +775,9 @@ if ($_GET["fu"]==7) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $leichtebt=$array["leichtebt"];
@@ -895,7 +901,7 @@ if ($_GET["fu"]==8) {
                                                 <?php
                                                 if ($moeglich>=1) {
                                                     ?>
-                                                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=9&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
+                                                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=9&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
                                                     <td>
                                                         <select name="neuinfa" style="width:50px;">
                                                             <?php
@@ -941,9 +947,9 @@ if ($_GET["fu"]==8) {
         </td></center>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
     include ("inc.header.php");
-    $zeiger2 = @mysql_query("SELECT id,leichtebt,leichtebt_bau,kolonisten,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger2 = @mysql_query("SELECT id,leichtebt,leichtebt_bau,kolonisten,spiel,cantox,besitzer,min1,min2,min3,vorrat,lemin,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array2 = @mysql_fetch_array($zeiger2);
     $spiel=$array2["spiel"];
     $cantox=$array2["cantox"];
@@ -962,7 +968,7 @@ if ($_GET["fu"]==9) {
     $leichtebt=$array2["leichtebt"];
     $leichtebt_bau=$array2["leichtebt_bau"];
     $kolonisten=$array2["kolonisten"];
-    $bauen=$_POST["neuinfa"];
+    $bauen=int_post('neuinfa');
     $koloschalter=1;
     $rohstoffschalter=1;
     if(($osys_1==21) or ($osys_2==21) or ($osys_3==21) or ($osys_4==21) or ($osys_5==21) or ($osys_6==21)){
@@ -993,7 +999,7 @@ if ($_GET["fu"]==9) {
             $min1=$min1-$bauen;
             $min2=$min2-$bauen;
         }
-        $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set leichtebt_bau=$leichtebt_bau,cantox=$cantox,min1=$min1,min2=$min2,kolonisten=$kolonisten,vorrat=$vorrat where besitzer=$spieler and id=".$_GET["pid"]);
+        $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set leichtebt_bau=$leichtebt_bau,cantox=$cantox,min1=$min1,min2=$min2,kolonisten=$kolonisten,vorrat=$vorrat where besitzer=$spieler and id=".$pid);
         $message="<center>".str_replace(array('{1}'),array($bauen),$lang['planetenalpha']['ausbildungneu'])."</center>";
     }
     ?>
@@ -1014,9 +1020,9 @@ if ($_GET["fu"]==9) {
         </script>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==10) {
+if ($fuid==10) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $schwerebt=$array["schwerebt"];
@@ -1145,7 +1151,7 @@ if ($_GET["fu"]==10) {
                                                 <?php
                                                 if ($moeglich>=1) {
                                                     ?>
-                                                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=11&pid=<?php echo $_GET["pid"]?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
+                                                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=11&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
                                                     <td>
                                                         <select name="neuinfa" style="width:50px;">
                                                             <?php
@@ -1191,9 +1197,9 @@ if ($_GET["fu"]==10) {
         </center>
     <?php include ("inc.footer.php");
 }
-if ($_GET["fu"]==11) {
+if ($fuid==11) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT id,schwerebt,schwerebt_bau,kolonisten,cantox,min1,min2,min3,lemin,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT id,schwerebt,schwerebt_bau,kolonisten,cantox,min1,min2,min3,lemin,osys_1,osys_2,osys_3,osys_4,osys_5,osys_6 FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $schwerebt=$array["schwerebt"];
@@ -1210,7 +1216,7 @@ if ($_GET["fu"]==11) {
     $osys_4=$array["osys_4"];
     $osys_5=$array["osys_5"];
     $osys_6=$array["osys_6"];
-    $bauen=$_POST["neuinfa"];
+    $bauen=int_post('neuinfa');
     $koloschalter=1;
     $rohstoffschalter=1;
     if(($osys_1==21) or ($osys_2==21) or ($osys_3==21) or ($osys_4==21) or ($osys_5==21) or ($osys_6==21)){
@@ -1246,7 +1252,7 @@ if ($_GET["fu"]==11) {
             $min2=$min2-($bauen*5);
             $min3=$min3-($bauen);
         }
-        $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set schwerebt_bau=$schwerebt_bau,cantox=$cantox,min1=$min1,min2=$min2,min3=$min3,kolonisten=$kolonisten,lemin=$lemin where besitzer=$spieler and id=".$_GET["pid"]);
+        $zeiger_temp = @mysql_query("UPDATE $skrupel_planeten set schwerebt_bau=$schwerebt_bau,cantox=$cantox,min1=$min1,min2=$min2,min3=$min3,kolonisten=$kolonisten,lemin=$lemin where besitzer=$spieler and id=".$pid);
         $message="<center>".str_replace(array('{1}'),array($bauen),$lang['planetenalpha']['ausbildungneuschwer'])."</center>";
     }
     ?>
@@ -1270,9 +1276,9 @@ if ($_GET["fu"]==11) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==12) {
+if ($fuid==12) {
     include ("inc.header.php");
-    $art=$_GET["art"];
+    $art=int_get('art');
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" scroll="auto" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <br>
@@ -1290,7 +1296,7 @@ if ($_GET["fu"]==12) {
         <center>
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=3&pid=<?php echo $_GET['pid']?>&art=<?php echo $art?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" onSubmit="return check();"></td>
+                    <td><form name="formular" method="post" action="planeten_alpha.php?fu=3&pid=<?php echo $pid?>&art=<?php echo $art?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>" onSubmit="return check();"></td>
                     <td><img src="../bilder/empty.gif" border="0" width="5" height="1"></td>
                     <td><center><?php echo $lang['planetenalpha']['stationsname']?></center></td>
                     <td></td>
@@ -1324,9 +1330,8 @@ if ($_GET["fu"]==12) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==13) {
+if ($fuid==13) {
     include ("inc.header.php");
-    $pid=$_GET["pid"];
     $s_zahl=0;
     $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where id=$pid");
     $array = @mysql_fetch_array($zeiger);

--- a/inhalt/planeten_beta.php
+++ b/inhalt/planeten_beta.php
@@ -1,10 +1,13 @@
 <?php 
-include ("../inc.conf.php");
-$langfile_1='planeten_beta';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'planeten_beta';
+$fuid = int_get('fu');
+$pid = int_get('pid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
 include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT besitzer,id,native_id,native_name,native_art_name,native_abgabe,native_bild,native_text,native_kol FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT besitzer,id,native_id,native_name,native_art_name,native_abgabe,native_bild,native_text,native_kol FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $native_id=$array["native_id"];
     $native_name=$array["native_name"];
@@ -103,9 +106,9 @@ include ("inc.header.php");
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_planeten where id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_planeten where id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $logbuch=$array["logbuch"];
     $logbuch=str_replace("\\", "",$logbuch);
@@ -126,7 +129,7 @@ if ($_GET["fu"]==2) {
         <center>
             <table border="0" cellspacing="0" cellpadding="0">
                 <tr>
-                    <td><form name="formular" method="post" action="planeten_beta.php?fu=3&pid=<?php echo $_GET["pid"]; ?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
+                    <td><form name="formular" method="post" action="planeten_beta.php?fu=3&pid=<?php echo $pid?>&uid=<?php echo $uid?>&sid=<?php echo $sid?>"></td>
                     <td><textarea style="width:390px;height:59px;" name="logbuchdaten"><?php echo $logbuch?></textarea></td>
                     <td></td>
                 </tr>
@@ -140,12 +143,12 @@ if ($_GET["fu"]==2) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     $eintrag=$_POST["logbuchdaten"];
     $eintrag=str_replace("\"", "\'",$eintrag);
     $eintrag=str_replace("\\", "",$eintrag);
-    $zeiger = @mysql_query("UPDATE $skrupel_planeten set logbuch=\"$eintrag\" where id=".$_GET["pid"]);
+    $zeiger = @mysql_query("UPDATE $skrupel_planeten set logbuch=\"$eintrag\" where id=".$pid);
     ?>
     <body text="#000000" background="<?php echo $bildpfad?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <br><br><br><br>
@@ -153,9 +156,9 @@ if ($_GET["fu"]==3) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT id,x_pos,y_pos FROM $skrupel_planeten where id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT id,x_pos,y_pos FROM $skrupel_planeten where id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $xpos=$array["x_pos"];
     $ypos=$array["y_pos"];

--- a/inhalt/planeten_gamma.php
+++ b/inhalt/planeten_gamma.php
@@ -1,10 +1,13 @@
 <?php 
-include ("../inc.conf.php");
-$langfile_1='planeten_gamma';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'planeten_gamma';
+$fuid = int_get('fu');
+$pid = int_get('pid');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];
@@ -224,27 +227,27 @@ if ($_GET["fu"]==1) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
         $auto_minen=0;
-        if ($_POST["minauto"]==1) { $auto_minen=1;$message="<center>".$lang['planetengamma']['mineautoja']."</center>"; } else { $auto_minen=0;$message="<center>".$lang['planetengamma']['mineautonein']."</center>"; }
-        $zeiger = @mysql_query("update $skrupel_planeten set auto_minen=$auto_minen where id=".$_GET["pid"]." and besitzer=$spieler");
+        if (int_post('minauto')==1) { $auto_minen=1;$message="<center>".$lang['planetengamma']['mineautoja']."</center>"; } else { $auto_minen=0;$message="<center>".$lang['planetengamma']['mineautonein']."</center>"; }
+        $zeiger = @mysql_query("update $skrupel_planeten set auto_minen=$auto_minen where id=".$pid." and besitzer=$spieler");
         ?>
         <br><br>
         <?php
         echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
-        $minenauftrag=$_POST["minenauftrag"];
-        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $minenauftrag=int_post('minenauftrag');
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $minen=$array["minen"];
@@ -292,9 +295,9 @@ if ($_GET["fu"]==3) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];
@@ -494,27 +497,27 @@ if ($_GET["fu"]==4) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==5) {
+if ($fuid==5) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
         $auto_fabriken=0;
-        if ($_POST["fabrikauto"]==1) { $auto_fabriken=1;$message="<center>".$lang['planetengamma']['fabrikautoja']."</center>"; } else { $auto_fabriken=0;$message="<center>".$lang['planetengamma']['farbikautonein']."</center>"; }
-        $zeiger = @mysql_query("update $skrupel_planeten set auto_fabriken=$auto_fabriken where id=".$_GET["pid"]." and besitzer=$spieler");
+        if (int_post('fabrikauto')==1) { $auto_fabriken=1;$message="<center>".$lang['planetengamma']['fabrikautoja']."</center>"; } else { $auto_fabriken=0;$message="<center>".$lang['planetengamma']['farbikautonein']."</center>"; }
+        $zeiger = @mysql_query("update $skrupel_planeten set auto_fabriken=$auto_fabriken where id=".$pid." and besitzer=$spieler");
         ?>
         <br><br>
         <?php 
         echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==6) {
+if ($fuid==6) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" scroll="no" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
-        $fabrikenauftrag=$_POST["fabrikenauftrag"];
-        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $fabrikenauftrag=int_post('fabrikenauftrag');
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $fabriken=$array["fabriken"];
@@ -562,13 +565,13 @@ if ($_GET["fu"]==6) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==7) {
+if ($fuid==7) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
-        $vorratauftrag=$_POST["vorratauftrag"];
-        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $vorratauftrag=int_post('vorratauftrag');
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $cantox=$array["cantox"];
@@ -590,23 +593,23 @@ if ($_GET["fu"]==7) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==8) {
+if ($fuid==8) {
     include ("inc.header.php");
     ?>
     <body text="#000000" scroll="no" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
         $auto_vorrat=0;
-        if ($_POST["vorratauto"]==1) { $auto_vorrat=1;$message="<center>".$lang['planetengamma']['vorratautoja']."</center>"; } else { $auto_vorrat=0;$message="<center>".$lang['planetengamma']['vorratautonein']."</center>"; }
-        $zeiger = @mysql_query("update $skrupel_planeten set auto_vorrat=$auto_vorrat where id=".$_GET["pid"]." and besitzer=$spieler");
+        if (int_post('vorratauto')==1) { $auto_vorrat=1;$message="<center>".$lang['planetengamma']['vorratautoja']."</center>"; } else { $auto_vorrat=0;$message="<center>".$lang['planetengamma']['vorratautonein']."</center>"; }
+        $zeiger = @mysql_query("update $skrupel_planeten set auto_vorrat=$auto_vorrat where id=".$pid." and besitzer=$spieler");
         ?>
         <br><br>
         <?php
         echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==9) {
+if ($fuid==9) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];
@@ -771,26 +774,26 @@ if ($_GET["fu"]==9) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==10) {
+if ($fuid==10) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" scroll="no" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
         $auto_abwehr=0;
-        if ($_POST["abwehrauto"]==1) { $auto_abwehr=1;$message="<center>".$lang['planetengamma']['pdsautoja']."</center>"; } else { $auto_abwehr=0;$message="<center>".$lang['planetengamma']['pdsautonein']."</center>"; }
-        $zeiger = @mysql_query("update $skrupel_planeten set auto_abwehr=$auto_abwehr where id=".$_GET["pid"]." and besitzer=$spieler");
+        if (int_post('abwehrauto')==1) { $auto_abwehr=1;$message="<center>".$lang['planetengamma']['pdsautoja']."</center>"; } else { $auto_abwehr=0;$message="<center>".$lang['planetengamma']['pdsautonein']."</center>"; }
+        $zeiger = @mysql_query("update $skrupel_planeten set auto_abwehr=$auto_abwehr where id=".$pid." and besitzer=$spieler");
         ?>
         <br><br>
         <?php echo $message;
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==11) {
+if ($fuid==11) {
     include ("inc.header.php");
     ?>
     <body text="#000000" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" scroll="no" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php 
-         $abwehrauftrag=$_POST["abwehrauftrag"];
-         $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+        $abwehrauftrag=int_post('abwehrauftrag');
+        $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
         $array = @mysql_fetch_array($zeiger);
         $pid=$array["id"];
         $cantox=$array["cantox"];
@@ -837,9 +840,9 @@ if ($_GET["fu"]==11) {
         <?php 
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==12) {
+if ($fuid==12) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$_GET["pid"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_planeten where besitzer=$spieler and id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $pid=$array["id"];
     $name=$array["name"];

--- a/inhalt/runde_ende.php
+++ b/inhalt/runde_ende.php
@@ -1,11 +1,15 @@
 <?php 
-include ("../inc.conf.php");
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
 if(empty($_GET['sprache'])){$_GET['sprache']=$language;}
 $file="../lang/".$_GET['sprache']."/lang.runde_ende.php";
 include ($file);
 if (($_GET["bildpfad"]=="bilder") or ($_GET["bildpfad"]=="")) {$_GET["bildpfad"]="../bilder";}
+$bildpfad = $_GET["bildpfad"];
+$spiel = int_get('spiel');
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     ?>
     <html>
         <head>
@@ -16,42 +20,42 @@ if ($_GET["fu"]==1) {
             <meta name="keywords" content=" ">
             <script language="JavaScript">
                 if(parent.frames.length>=1) {
-                    window.top.location.href="runde_ende.php?fu=1&spiel=<?php echo $_GET["spiel"]?>&bildpfad=<?php echo $_GET["bildpfad"]?>";
+                    window.top.location.href="runde_ende.php?fu=1&spiel=<?php echo $spiel?>&bildpfad=<?php echo $bildpfad?>";
                 }
             </script>
         </head>
         <frameset framespacing="0" border="false" frameborder="0" rows="*,18,508,16,*">
             <frame name="rahmenk" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0" target="_self">
             <frameset framespacing="0" border="false" frameborder="0" cols="*,114,670,114,*">
-                <frame name="rahmen0" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen1" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=19&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen2" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=20&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen3" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=21&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen4" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                <frame name="rahmen0" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen1" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=19&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen2" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=20&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen3" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=21&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen4" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
             </frameset>
             <frameset framespacing="0" border="false" frameborder="0" cols="*,18,862,18,*">
-                <frame name="rahmen10" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                <frame name="rahmen10" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
                 <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
-                    <frame name="rahmen15" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=25&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                    <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                    <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                    <frame name="rahmen15" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=25&bildpfad=<?php echo $bildpfad?>" target="_self">
+                    <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad?>" target="_self">
+                    <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad?>" target="_self">
                 </frameset>
-                <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="runde_ende.php?fu=2&spiel=<?php echo $_GET["spiel"]?>&bildpfad=<?php echo $_GET["bildpfad"]?>&sprache=<?php echo $_GET['sprache']?>" target="_self">
+                <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="runde_ende.php?fu=2&spiel=<?php echo $spiel?>&bildpfad=<?php echo $bildpfad?>&sprache=<?php echo $_GET['sprache']?>" target="_self">
                 <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
-                    <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                    <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                    <frame name="rahmen20" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=30&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                    <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad?>" target="_self">
+                    <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad?>" target="_self">
+                    <frame name="rahmen20" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=30&bildpfad=<?php echo $bildpfad?>" target="_self">
                 </frameset>
-                <frame name="rahmen14" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                <frame name="rahmen14" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
             </frameset>
             <frameset framespacing="0" border="false" frameborder="0" cols="*,114,670,114,*">
-                <frame name="rahmen5" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen6" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=22&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen7" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=23&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen8" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=24&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
-                <frame name="rahmen9" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+                <frame name="rahmen5" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen6" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=22&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen7" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=23&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen8" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=24&bildpfad=<?php echo $bildpfad?>" target="_self">
+                <frame name="rahmen9" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
             </frameset>
-            <frame name="rahmenk" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $_GET["bildpfad"]?>" target="_self">
+            <frame name="rahmenk" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=0&bildpfad=<?php echo $bildpfad?>" target="_self">
         </frameset>
         <noframes>
         <body>
@@ -59,7 +63,7 @@ if ($_GET["fu"]==1) {
     </html>
     <?php 
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $zeiger = @mysql_query("SELECT extend,serial FROM $skrupel_info");
@@ -79,7 +83,7 @@ if ($_GET["fu"]==2) {
         }
     }
     compressed_output();
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where phase=1 and id=".$_GET["spiel"]);
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where phase=1 and id=".$spiel);
     $datensaetze = @mysql_num_rows($zeiger);
     if ($datensaetze==1) {
         $array = @mysql_fetch_array($zeiger);
@@ -290,7 +294,7 @@ if ($_GET["fu"]==2) {
                 <table border="0" cellspacing="0" cellpadding="0" width="100%">
                     <tr>
                         <td><img src="../bilder/empty.gif" border="0" width="10" height="1"></td>
-                        <td><img src="<?php echo $_GET["bildpfad"]?>/logo_login.gif" width="329" height="208"></td>
+                        <td><img src="<?php echo $bildpfad?>/logo_login.gif" width="329" height="208"></td>
                         <td><img src="../bilder/empty.gif" border="0" width="10" height="1"></td>
                         <td width="100%">
                             <center>
@@ -349,10 +353,10 @@ if ($_GET["fu"]==2) {
                                 <table border="0" cellspacing="0" cellpadding="3" width="100%">
                                     <tr>
                                         <td width="100%"><img src="../lang/<?php echo $_GET['sprache']?>/topics/dieimperien.gif" border="0" width="185" height="52"></td>
-                                        <td><center><img src="<?php echo $_GET["bildpfad"]?>/aufbau/rang_1.gif" border="0" width="41" height="41"></center></td>
-                                        <td><center><img src="<?php echo $_GET["bildpfad"]?>/aufbau/rang_2.gif" border="0" width="41" height="41"></center></td>
-                                        <td><center><img src="<?php echo $_GET["bildpfad"]?>/aufbau/rang_3.gif" border="0" width="41" height="41"></center></td>
-                                        <td><center><img src="<?php echo $_GET["bildpfad"]?>/aufbau/rang_4.gif" border="0" width="113" height="41"></center></td>
+                                        <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_1.gif" border="0" width="41" height="41"></center></td>
+                                        <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_2.gif" border="0" width="41" height="41"></center></td>
+                                        <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_3.gif" border="0" width="41" height="41"></center></td>
+                                        <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_4.gif" border="0" width="113" height="41"></center></td>
                                     </tr>
                                     <?php 
                                     if ($spieler_1>=1) {
@@ -621,14 +625,14 @@ if ($_GET["fu"]==2) {
                                             <center>
                                                 <table border="0" cellspacing="0" cellpadding="0">
                                                     <tr>
-                                                        <td colspan="3"><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galaoben.gif" border="0" width="258" height="4"></td>
+                                                        <td colspan="3"><img src="<?php echo $bildpfad?>/aufbau/galaoben.gif" border="0" width="258" height="4"></td>
                                                     </tr>
                                                     <tr>
-                                                        <td><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galalinks.gif" border="0" width="4" height="250"></td>
-                                                        <td><iframe src="../extend/moviegif/movie.php?fu=1&spiel=<?php echo $_GET["spiel"]?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
-                                                        <td><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galarechts.gif" border="0" width="4" height="250"></td>
+                                                        <td><img src="<?php echo $bildpfad?>/aufbau/galalinks.gif" border="0" width="4" height="250"></td>
+                                                        <td><iframe src="../extend/moviegif/movie.php?fu=1&spiel=<?php echo $spiel?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
+                                                        <td><img src="<?php echo $bildpfad?>/aufbau/galarechts.gif" border="0" width="4" height="250"></td>
                                                     <tr>
-                                                        <td colspan="3"><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galaunten.gif" border="0" width="258" height="4"></td>
+                                                        <td colspan="3"><img src="<?php echo $bildpfad?>/aufbau/galaunten.gif" border="0" width="258" height="4"></td>
                                                     </tr>
                                                 </table>
                                             </center>
@@ -644,14 +648,14 @@ if ($_GET["fu"]==2) {
                                             <center>
                                                 <table border="0" cellspacing="0" cellpadding="0">
                                                     <tr>
-                                                        <td colspan="3"><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galaoben.gif" border="0" width="258" height="4"></td>
+                                                        <td colspan="3"><img src="<?php echo $bildpfad?>/aufbau/galaoben.gif" border="0" width="258" height="4"></td>
                                                     </tr>
                                                     <tr>
-                                                        <td><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galalinks.gif" border="0" width="4" height="250"></td>
-                                                        <td><iframe src="runde_ende.php?fu=3&spiel=<?php echo $_GET["spiel"]?>&bildpfad=<?php echo $_GET["bildpfad"]?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
-                                                        <td><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galarechts.gif" border="0" width="4" height="250"></td>
+                                                        <td><img src="<?php echo $bildpfad?>/aufbau/galalinks.gif" border="0" width="4" height="250"></td>
+                                                        <td><iframe src="runde_ende.php?fu=3&spiel=<?php echo $spiel?>&bildpfad=<?php echo $bildpfad?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
+                                                        <td><img src="<?php echo $bildpfad?>/aufbau/galarechts.gif" border="0" width="4" height="250"></td>
                                                     <tr>
-                                                        <td colspan="3"><img src="<?php echo $_GET["bildpfad"]?>/aufbau/galaunten.gif" border="0" width="258" height="4"></td>
+                                                        <td colspan="3"><img src="<?php echo $bildpfad?>/aufbau/galaunten.gif" border="0" width="258" height="4"></td>
                                                     </tr>
                                                 </table>
                                             </center>
@@ -671,10 +675,9 @@ if ($_GET["fu"]==2) {
     }
     @mysql_close();
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     $breite=250;
     $hoehe=250;
-    $spiel=$_GET["spiel"];
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     function compressed_output(){
@@ -690,7 +693,7 @@ if ($_GET["fu"]==3) {
         }
     }
     compressed_output();
-    $zeiger = @mysql_query("SELECT id,phase,umfang FROM $skrupel_spiele where phase=1 and id=".$_GET["spiel"]);
+    $zeiger = @mysql_query("SELECT id,phase,umfang FROM $skrupel_spiele where phase=1 and id=".$spiel);
     $datensaetze = @mysql_num_rows($zeiger);
     if ($datensaetze==1) {
         $array_temp = @mysql_fetch_array($zeiger);
@@ -791,7 +794,7 @@ if ($_GET["fu"]==3) {
             <body text="#000000" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
                 <table border="0" cellspacing="0" cellpadding="0">
                     <tr>
-                        <td><img src="<?php echo $_GET["bildpfad"]?>/karte/mapklein.gif" width="<?php echo $breite?>" height="<?php echo $hoehe?>"></td>
+                        <td><img src="<?php echo $bildpfad?>/karte/mapklein.gif" width="<?php echo $breite?>" height="<?php echo $hoehe?>"></td>
                     </tr>
                 </table>
                 <?php 

--- a/inhalt/uebersicht.php
+++ b/inhalt/uebersicht.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='uebersicht';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'uebersicht';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#000000" bgcolor="#444444" style="background-image:url('<?php echo $bildpfad?>/aufbau/14.gif'); background-attachment:fixed;" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/uebersicht_imperien.php
+++ b/inhalt/uebersicht_imperien.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='uebersicht_imperien';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'uebersicht_imperien';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
         $farbe="5f4444";
         ?>
@@ -146,9 +148,9 @@ if ($_GET["fu"]==1) {
             <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
-        if ($spieler==$_GET["spid"]) {
+        if ($spieler==int_get('spid')) {
             $rassenname=$spieler_rassename_c[$spieler];
             ?>
             <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -178,9 +180,9 @@ if ($_GET["fu"]==2) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
-        if ($spieler==$_GET["spid"]) {
+        if ($spieler==int_get('spid')) {
             $spalte="spieler_".$spieler."_rassename";
             $zeiger_temp= @mysql_query("UPDATE $skrupel_spiele set $spalte='".$_POST['neu_name']."' where id=$spiel");
             ?>
@@ -191,9 +193,9 @@ if ($_GET["fu"]==3) {
         }
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     include ("inc.header.php");
-        $spid=$_GET["spid"];
+        $spid=int_get('spid');
         $zeiger_temp= @mysql_query("SELECT * FROM $skrupel_user where id=$spid");
         $array_temp = @mysql_fetch_array($zeiger_temp);
         $nick=$array_temp["nick"];

--- a/inhalt/uebersicht_kolonien.php
+++ b/inhalt/uebersicht_kolonien.php
@@ -1,9 +1,11 @@
 <?php 
-include ("../inc.conf.php");
-$langfile_1='uebersicht_kolonien';
-$langfile_2='orbitale_systeme';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'uebersicht_kolonien';
+$langfile_2 = 'orbitale_systeme';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     ?>
     <body text="#ffffff" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/uebersicht_konplaene.php
+++ b/inhalt/uebersicht_konplaene.php
@@ -1,8 +1,10 @@
 <?php 
-include ("../inc.conf.php");
-$langfile_1='uebersicht_konplaene';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'uebersicht_konplaene';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     
     include ("inc.header.php");
     ?>

--- a/inhalt/uebersicht_neuigkeiten.php
+++ b/inhalt/uebersicht_neuigkeiten.php
@@ -3,9 +3,8 @@
 :noTabs=false:indentSize=4:tabSize=4:folding=explicit:collapseFolds=1:
 */
 include ('../inc.conf.php');
-$langfile_1='uebersicht_neuigkeiten';
 include_once ('inc.hilfsfunktionen.php');
-
+$langfile_1 = 'uebersicht_neuigkeiten';
 $fuid = int_get('fu');
 
 //fu:1 Nachrichten anzeigen {{{

--- a/inhalt/uebersicht_uebersicht.php
+++ b/inhalt/uebersicht_uebersicht.php
@@ -1,8 +1,10 @@
 <?php
-include ("../inc.conf.php");
-$langfile_1='uebersicht_uebersicht';
+include ('../inc.conf.php');
+include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'uebersicht_uebersicht';
+$fuid = int_get('fu');
 
-if ($_GET["fu"]==1) {
+if ($fuid==1) {
     include ("inc.header.php");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where id=$spiel");
     $array = @mysql_fetch_array($zeiger);
@@ -73,7 +75,7 @@ if ($_GET["fu"]==1) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==2) {
+if ($fuid==2) {
     include ("inc.header.php");
     ?><body onLoad="window.location='uebersicht_uebersicht.php?fu=3&uid=<?php echo $uid?>&sid=<?php echo $sid?>';" text="#000000" bgcolor="#000000"   link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <center>
@@ -84,7 +86,7 @@ if ($_GET["fu"]==2) {
         <?php
     include ("inc.footer.php");
 }
-if ($_GET["fu"]==3) {
+if ($fuid==3) {
     include ("inc.header.php");
     if ((@extension_loaded('gd')) or (@dl('gd.so'))) {
         ?>    
@@ -264,7 +266,7 @@ if ($_GET["fu"]==3) {
         include ("inc.footer.php");
     }
 }
-if ($_GET["fu"]==4) {
+if ($fuid==4) {
     $conn = @mysql_connect($server.':'.$port,$login,$password);
     $db = @mysql_select_db($database,$conn);
     include ('inc.check.php');

--- a/inhalt/zugende.php
+++ b/inhalt/zugende.php
@@ -3,8 +3,8 @@
 :noTabs=false:indentSize=4:tabSize=4:folding=explicit:collapseFolds=1:
 */
 include ('../inc.conf.php');
-$langfile_1='zugende';
 include_once ('inc.hilfsfunktionen.php');
+$langfile_1 = 'zugende';
 $fuid = int_get('fu');
 
 //fu:1 Zugende Hauptmenu {{{


### PR DESCRIPTION
Ein Großteil der bisher möglichen SQL-Injections sollte nun unterbunden sein (Ticket 0013):
- genutzt werden nun konsequent die bereits vorhandenen und teilweise bereits zuvor verwendeten Funkionen int_get und int_post (aus der hilfsfunktionen-Datei)
- es werden aktuell nur Zahlen geprüft; d.h. nur bei $_GET/$_POST-Variablen, wo ich mir sicher war, daß es sich um Zahlen handelt, wurden die Veränderungen eingebaut
- auch einige Stellen, die nicht direkt für SQL-Injections verwendbar gewesen sein sollten, wie z.B. die zig $_GET["fu"] werden nun einheitlich behandelt (zum einen war das in einigen Files bereits vorher der Fall und zum anderen hat man so wesentlich einfacher die übrigen kritischen Stellen im Blick)
