### PR TITLE
Prüfen der GET/POST-Strings

### DIFF
--- a/admin/allgemein_alpha.php
+++ b/admin/allgemein_alpha.php
@@ -23,7 +23,7 @@ if ($fuid==1) {
                             <br>
                             <center><?php echo $lang['admin']['allgemein']['alpha']['offenbarung_text']?></center>
                             <form name="formular" method="post" action="allgemein_alpha.php?fu=2">
-                            <textarea name="nachricht" style="width:100%;height:255px;"></textarea>
+                            <textarea name="offenbarung" style="width:100%;height:255px;"></textarea>
                             <br><br>
                             <center>
                                 <table border="0" cellspacing="0" cellpadding="0">
@@ -53,7 +53,7 @@ if ($fuid==2) {
 
         $letzter=time();
 
-        $beitrag=$_POST["nachricht"];
+        $beitrag=str_post('offenbarung','SQLSAFE');
 
         $thema=substr($beitrag,0,30)."...";
         $thema=str_replace("&","&amp;",$thema);
@@ -64,10 +64,10 @@ if ($fuid==2) {
         $beitrag=str_replace("<","&lt;",$beitrag);
         $beitrag=str_replace(">","&gt;",$beitrag);
 
-        $beitrag=nl2br(stripslashes($beitrag));
-        $beitrag=str_replace("'", "",$beitrag);
-        $beitrag=str_replace("\"", "",$beitrag);
-        $beitrag=str_replace("\\", "",$beitrag);
+        //$beitrag=nl2br(stripslashes($beitrag));
+        //$beitrag=str_replace("'", "",$beitrag);
+        //$beitrag=str_replace("\"", "",$beitrag);
+        //$beitrag=str_replace("\\", "",$beitrag);
 
         $zeiger = @mysql_query("INSERT INTO $skrupel_forum_thema (forum,icon,thema,beginner,antworten,letzter) values ($forum,$icon,'$thema','$beginner',0,'$letzter');");
 

--- a/admin/allgemein_beta.php
+++ b/admin/allgemein_beta.php
@@ -134,7 +134,7 @@ if ($fuid==2) {
         $chat=int_post('chat');
         $anleitung=int_post('anleitung');
         $forum=int_post('forum');
-        $forum_url=$_POST["forum_url"];
+        $forum_url=str_post('forum_url','SQLSAFE');
         $zeiger = @mysql_query("update $skrupel_info set chat=$chat, anleitung=$anleitung, forum=$forum, forum_url='$forum_url'");
         ?>
         <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/admin/mitspieler_alpha.php
+++ b/admin/mitspieler_alpha.php
@@ -32,9 +32,9 @@ if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
 if ($fuid==2) {
 include ("inc.header.php");
 if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-$nick=$_POST["nick"];
-$email=$_POST["email"];
-$passwort=$_POST["passwort"];
+$nick=str_post('nick','SQLSAFE');
+$email=str_post('email','SQLSAFE');
+$passwort=str_post('passwort','SQLSAFE');
 $zeiger = @mysql_query("INSERT INTO $skrupel_user (nick,passwort,email,optionen,sprache) values ('$nick','$passwort','$email','00111111111000', '$language')");
 ?>
 <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/admin/spiel_alpha.php
+++ b/admin/spiel_alpha.php
@@ -173,7 +173,7 @@ if ($fp) {
 while (!feof ($fp)) {
     $buffer = @fgets($fp, 4096);
     $strukturdaten=explode(':',$buffer);
-    if ($strukturdaten[1]==$_POST["struktur"]) {
+    if ($strukturdaten[1]==str_post('struktur','SHORTNAME')) {
        $spieleranzahlmog=trim($strukturdaten[2]);
     }
 }
@@ -421,7 +421,7 @@ include ("inc.footer.php");
  }
 if ($fuid==4) {
 include ("inc.header.php");
-if ((int_get('startposset') !== 1) and (int_post('startposition') == 3)) {
+if ((int_get('startposset') != 1) and (int_post('startposition') == 3)) {
 ?>
 <script type="text/javascript">
     function check () {
@@ -455,7 +455,7 @@ foreach ($_POST as $key => $value) {
             </tr>
             <tr>
               <td><img src="../bilder/aufbau/galalinks.gif" border="0" width="4" height="250"></td>
-              <td><iframe src="spiel_alpha.php?fu=12&struktur=<?php echo $_POST["struktur"]; ?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
+              <td><iframe src="spiel_alpha.php?fu=12&struktur=<?php echo str_post('struktur','SHORTNAME'); ?>" width="250" height="250" name="map" scrolling="no" marginheight="0" marginwidth="0" frameborder="0"></iframe></td>
               <td><img src="../bilder/aufbau/galarechts.gif" border="0" width="4" height="250"></td>
             </tr>
             <tr>
@@ -803,7 +803,7 @@ function getMouseXY(e) {
 </script>
 <body text="#ffffff" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
 <div id="galastruktur" style="z-index:1;position: absolute; left:0px; top:0px; width: 250px; height: 250px;">
-    <img src="../daten/bilder_galaxien/<?php echo $_GET['struktur']; ?>.png" width="250" height="250">
+    <img src="../daten/bilder_galaxien/<?php echo str_get('struktur','SHORTNAME'); ?>.png" width="250" height="250">
 </div>
 <div id="stars" style="z-index:2;position: absolute; left:0px; top:0px; width: 250px; height: 250px;">
     <img src="../bilder/admin/gala_stars_big.gif" width="250" height="250" border="0">
@@ -895,28 +895,28 @@ function zufallstring($size = 20, $url = ONLY_LETTERS){
   $spiel_serial=$array["serial"];
 //////////////////////////////////////
 $sid=zufallstring();
-$spielname=$_POST["spiel_name"];
-   $spielname=str_replace("'"," ",$spielname);
-   $spielname=str_replace('"'," ",$spielname);
+$spielname=str_post('spiel_name','SQLSAFE');
+   //$spielname=str_replace("'"," ",$spielname);
+   //$spielname=str_replace('"'," ",$spielname);
 $ziel_id=int_post('siegbedingungen');
 $umfang=int_post('umfang');
-$struktur=$_POST["struktur"];
+$struktur=str_post('struktur','SHORTNAME');
 $piraten_mitte=int_post('piraten_mitte');
 $piraten_aussen=int_post('piraten_aussen');
 $piraten_min=int_post('piraten_min');
 $piraten_max=int_post('piraten_max');
 $out=int_post('out');
 if ($ziel_id==6) {
- $team[1]=$_POST["team1"];
- $team[2]=$_POST["team2"];
- $team[3]=$_POST["team3"];
- $team[4]=$_POST["team4"];
- $team[5]=$_POST["team5"];
- $team[6]=$_POST["team6"];
- $team[7]=$_POST["team7"];
- $team[8]=$_POST["team8"];
- $team[9]=$_POST["team9"];
- $team[10]=$_POST["team10"];
+ $team[1]=int_post('team1');
+ $team[2]=int_post('team2');
+ $team[3]=int_post('team3');
+ $team[4]=int_post('team4');
+ $team[5]=int_post('team5');
+ $team[6]=int_post('team6');
+ $team[7]=int_post('team7');
+ $team[8]=int_post('team8');
+ $team[9]=int_post('team9');
+ $team[10]=int_post('team10');
 }
 $module = array();
 $module[0] = int_post('modul_0');
@@ -1122,16 +1122,16 @@ if (int_post('spezien')>=1) {
 ///////////////////////////////////////////////PLANETEN GENRERIEREN ENDE
 ////////////////////////////////////////////////WER SPIELT MIT
 $spieleranzahl=0;
-if (int_post('user_1')>=1) { $spieleranzahl++;$spieler[1][0]=int_post('user_1');$spieler[1][1]=$_POST["rasse_1"]; } else { $spieler[1][0]=0;$spieler[1][1]=''; }
-if (int_post('user_2')>=1) { $spieleranzahl++;$spieler[2][0]=int_post('user_2');$spieler[2][1]=$_POST["rasse_2"]; } else { $spieler[2][0]=0;$spieler[2][1]=''; }
-if (int_post('user_3')>=1) { $spieleranzahl++;$spieler[3][0]=int_post('user_3');$spieler[3][1]=$_POST["rasse_3"]; } else { $spieler[3][0]=0;$spieler[3][1]=''; }
-if (int_post('user_4')>=1) { $spieleranzahl++;$spieler[4][0]=int_post('user_4');$spieler[4][1]=$_POST["rasse_4"]; } else { $spieler[4][0]=0;$spieler[4][1]=''; }
-if (int_post('user_5')>=1) { $spieleranzahl++;$spieler[5][0]=int_post('user_5');$spieler[5][1]=$_POST["rasse_5"]; } else { $spieler[5][0]=0;$spieler[5][1]=''; }
-if (int_post('user_6')>=1) { $spieleranzahl++;$spieler[6][0]=int_post('user_6');$spieler[6][1]=$_POST["rasse_6"]; } else { $spieler[6][0]=0;$spieler[6][1]=''; }
-if (int_post('user_7')>=1) { $spieleranzahl++;$spieler[7][0]=int_post('user_7');$spieler[7][1]=$_POST["rasse_7"]; } else { $spieler[7][0]=0;$spieler[7][1]=''; }
-if (int_post('user_8')>=1) { $spieleranzahl++;$spieler[8][0]=int_post('user_8');$spieler[8][1]=$_POST["rasse_8"]; } else { $spieler[8][0]=0;$spieler[8][1]=''; }
-if (int_post('user_9')>=1) { $spieleranzahl++;$spieler[9][0]=int_post('user_9');$spieler[9][1]=$_POST["rasse_9"]; } else { $spieler[9][0]=0;$spieler[9][1]=''; }
-if (int_post('user_10')>=1) { $spieleranzahl++;$spieler[10][0]=int_post('user_10');$spieler[10][1]=$_POST["rasse_10"]; } else { $spieler[10][0]=0;$spieler[10][1]=''; }
+if (int_post('user_1')>=1) { $spieleranzahl++;$spieler[1][0]=int_post('user_1');$spieler[1][1]=str_post('rasse_1','SHORTNAME'); } else { $spieler[1][0]=0;$spieler[1][1]=''; }
+if (int_post('user_2')>=1) { $spieleranzahl++;$spieler[2][0]=int_post('user_2');$spieler[2][1]=str_post('rasse_2','SHORTNAME'); } else { $spieler[2][0]=0;$spieler[2][1]=''; }
+if (int_post('user_3')>=1) { $spieleranzahl++;$spieler[3][0]=int_post('user_3');$spieler[3][1]=str_post('rasse_3','SHORTNAME'); } else { $spieler[3][0]=0;$spieler[3][1]=''; }
+if (int_post('user_4')>=1) { $spieleranzahl++;$spieler[4][0]=int_post('user_4');$spieler[4][1]=str_post('rasse_4','SHORTNAME'); } else { $spieler[4][0]=0;$spieler[4][1]=''; }
+if (int_post('user_5')>=1) { $spieleranzahl++;$spieler[5][0]=int_post('user_5');$spieler[5][1]=str_post('rasse_5','SHORTNAME'); } else { $spieler[5][0]=0;$spieler[5][1]=''; }
+if (int_post('user_6')>=1) { $spieleranzahl++;$spieler[6][0]=int_post('user_6');$spieler[6][1]=str_post('rasse_6','SHORTNAME'); } else { $spieler[6][0]=0;$spieler[6][1]=''; }
+if (int_post('user_7')>=1) { $spieleranzahl++;$spieler[7][0]=int_post('user_7');$spieler[7][1]=str_post('rasse_7','SHORTNAME'); } else { $spieler[7][0]=0;$spieler[7][1]=''; }
+if (int_post('user_8')>=1) { $spieleranzahl++;$spieler[8][0]=int_post('user_8');$spieler[8][1]=str_post('rasse_8','SHORTNAME'); } else { $spieler[8][0]=0;$spieler[8][1]=''; }
+if (int_post('user_9')>=1) { $spieleranzahl++;$spieler[9][0]=int_post('user_9');$spieler[9][1]=str_post('rasse_9','SHORTNAME'); } else { $spieler[9][0]=0;$spieler[9][1]=''; }
+if (int_post('user_10')>=1) { $spieleranzahl++;$spieler[10][0]=int_post('user_10');$spieler[10][1]=str_post('rasse_10','SHORTNAME'); } else { $spieler[10][0]=0;$spieler[10][1]=''; }
 ///////////////////////////////////////////////SPIELER AUFBAUEN ANFANG
 ///////////////////////////////////////////////STARTPOSITIONEN
 if ($startposition==1) {
@@ -1414,7 +1414,7 @@ $spieler_1_ziel='';$spieler_2_ziel='';$spieler_3_ziel='';
 $spieler_4_ziel='';$spieler_5_ziel='';$spieler_6_ziel='';
 $spieler_7_ziel='';$spieler_8_ziel='';$spieler_9_ziel='';$spieler_10_ziel='';
 if ($ziel_id==1) {
-   $ziel_info=$_POST["zielinfo_1"];
+   $ziel_info=int_post('zielinfo_1');
 }
 if ($ziel_id==2) {
   $feind=0;$checkstring='';$zahl=0;
@@ -1499,7 +1499,7 @@ if ($ziel_id==6) {
   }
 }
 if ($ziel_id==5) {
-   $ziel_info=$_POST["zielinfo_5"];
+   $ziel_info=int_post('zielinfo_5');
    $spieler_1_ziel="0";
    $spieler_2_ziel="0";
    $spieler_3_ziel="0";

--- a/admin/spiel_beta.php
+++ b/admin/spiel_beta.php
@@ -502,16 +502,16 @@ include ("inc.footer.php");
 if ($fuid==3) {
   include ("inc.header.php");
   if (($ftploginname==$admin_login) and ($ftploginpass==$admin_pass)) {
-  $spiel=int_get('slot_id');
-  $spiel_name=$_POST["spiel_name"];
+  $spiel = int_get('slot_id');
+  $spiel_name = str_post('spiel_name','SQLSAFE');
   $module = array();
   $module[0] = int_post('modul_0');
   $module[1] = 0;
   $module[2] = int_post('modul_2');
   $module[3] = int_post('modul_3');
-    $module[4] = int_post('modul_4');
-    $module[5] = int_post('modul_5');
-    $module[6] = int_post('modul_6');  
+  $module[4] = int_post('modul_4');
+  $module[5] = int_post('modul_5');
+  $module[6] = int_post('modul_6');
   $module = @implode(":", $module);
   $aufloesung=int_post('aufloesung');
   $autotick=int_post('autotick');

--- a/index.php
+++ b/index.php
@@ -4,11 +4,12 @@
 */
 include ('inc.conf.php');
 include_once ('inhalt/inc.hilfsfunktionen.php');
-if(isset($_GET['sprache']) && preg_match('/[a-z]{2}/', $_GET['sprache']) && is_dir("lang/".$_GET['sprache'])) {
-  include ("lang/".$_GET['sprache']."/lang.index.php");
-} else {
-  include ("lang/".$language."/lang.index.php");
+$sprache = str_get('sprache','SHORTNAME');
+if ($sprache=='' || !preg_match('/^[a-z]{2}$/', $sprache) || !is_dir('lang/'.$sprache)) {
+  $sprache = $language;
 }
+include ('lang/'.$sprache.'/lang.index.php');
+
 $conn = @mysql_connect($server.':'.$port,$login,$password);
 $db = @mysql_select_db($database,$conn);
 function compressed_output() {
@@ -36,16 +37,16 @@ if ($db) {
   if (!preg_match('/Skrupel/i',getEnv("HTTP_USER_AGENT"))) {
     $bildpfad = 'bilder';
   }
-  if( ($tmp = str_get('pic_path')) !== false) {
+  if( ($tmp = str_get('pic_path','PATHNAME')) !== false) {
     $bildpfad = $tmp;
-  } elseif( ($tmp = str_post('pic_path')) !== false) {
+  } elseif( ($tmp = str_post('pic_path','PATHNAME')) !== false) {
     $bildpfad = $tmp;
   }
-  $login_f  = str_post('login_f');
-  $pass_f    = str_post('passwort_f');
+  $login_f  = str_post('login_f','SQLSAFE');
+  $pass_f    = str_post('passwort_f','SQLSAFE');
   $spiel_slot = int_post('spiel_slot');
 ///////////////////////////////login ueber link
-  if (($hash_f = str_get('hash')) !== false) {
+  if (($hash_f = str_get('hash','SQLSAFE')) !== false) {
     $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele WHERE
       spieler_1_hash = '$hash_f' or
       spieler_2_hash = '$hash_f' or
@@ -81,9 +82,9 @@ if ($db) {
       $array = @mysql_fetch_array($zeiger);
       $spieler_id = $array['id'];
       $spieler_name = $array['nick'];
-      $_GET['sprache'] = $array['sprache'];
-      if($_GET['sprache']==''){
-        $_GET['sprache']=$language;
+      $spieler_sprache = $array['sprache'];
+      if ($spieler_sprache=='') {
+        $spieler_sprache=$language;
       }
       $zeiger2 = @mysql_query("SELECT * FROM $skrupel_spiele WHERE (spieler_1=$spieler_id or spieler_2=$spieler_id or spieler_3=$spieler_id or spieler_4=$spieler_id or spieler_5=$spieler_id or spieler_6=$spieler_id or spieler_7=$spieler_id or spieler_8=$spieler_id or spieler_9=$spieler_id or spieler_10=$spieler_id) and id=$spiel_slot");
       if (@mysql_num_rows($zeiger2)==1) {
@@ -107,7 +108,7 @@ if ($db) {
   }
   if ($spieler>0)  {
     if ($phase==1) {
-      header("Location: inhalt/runde_ende.php?fu=1&spiel=$spiel&bildpfad=$bildpfad&sprache=".$_GET['sprache']);
+      header("Location: inhalt/runde_ende.php?fu=1&spiel=$spiel&bildpfad=$bildpfad&sprache=".$spieler_sprache);
       exit;
     }
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/inhalt/admin.php
+++ b/inhalt/admin.php
@@ -367,10 +367,10 @@ if ($fuid==4) {
     if ($spieler==$spieler_admin) {
         $uid = int_post('spielerid');
         if (($uid>1) and ($spieler_1<>$uid) and ($spieler_2<>$uid) and ($spieler_3<>$uid) and ($spieler_4<>$uid) and ($spieler_5<>$uid) and ($spieler_6<>$uid) and ($spieler_7<>$uid) and ($spieler_8<>$uid) and ($spieler_9<>$uid) and ($spieler_10<>$uid)) {
-            $kord=explode("-",$_POST["koord"]);
+            $kord=explode("-",str_post('koord','DEFAULT'));
             $i=int_post('slot');
             $ausstattung=int_post('ausstattung');
-            $rasse=$_POST["rasse"];
+            $rasse=str_post('rasse','SHORTNAME');
 ///////////////////////////////////////////////////////////////////////////////////////////////RASSENEIGENSCHAFTEN ANFANG
             $daten_verzeichnis="../daten/";
             $handle=opendir("$daten_verzeichnis");

--- a/inhalt/aufbau.php
+++ b/inhalt/aufbau.php
@@ -2,14 +2,15 @@
 include ('../inc.conf.php');
 include_once ('../inhalt/inc.hilfsfunktionen.php');
 $fuid = int_get('fu');
-if(empty($_GET["bildpfad"])) {$_GET["bildpfad"]='../bilder';}
+$bildpfad = str_get('bildpfad','PATHNAME');
+if ($bildpfad=='') {$bildpfad='../bilder';}
 
 if ($fuid==0) { ?>
     <html>
         <head>
             <META NAME="Author" CONTENT="Bernd Kantoks bernd@kantoks.de">
         </head>
-        <body text="#000000" bgcolor="#000000" background="<?php echo $_GET["bildpfad"]; ?>/hintergrund.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+        <body text="#000000" bgcolor="#000000" background="<?php echo $bildpfad; ?>/hintergrund.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         </body>
     </html>
 <?php }
@@ -38,7 +39,7 @@ if (($fuid>=1) and ($fuid<=99)) {
             <head>
                 <META NAME="Author" CONTENT="Bernd Kantoks bernd@kantoks.de">
             </head>
-            <body text="#000000" bgcolor="#444444" background="<?php echo $_GET["bildpfad"]; ?>/aufbau/<?php echo $fuid; ?>.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+            <body text="#000000" bgcolor="#444444" background="<?php echo $bildpfad; ?>/aufbau/<?php echo $fuid; ?>.gif" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
             </body>
         </html>
     <?php } ?>

--- a/inhalt/basen_alpha.php
+++ b/inhalt/basen_alpha.php
@@ -1042,7 +1042,7 @@ if ($fuid==6) {
     $planet_min2=(int_post('planet_min2')<0)?0:int_post('planet_min2');
     $planet_min3=(int_post('planet_min3')<0)?0:int_post('planet_min3');
     $planet_vorrat=(int_post('planet_vorrat')<0)?0:int_post('planet_vorrat');
-    $zielid=$_POST["zielid"];
+    $zielid=str_post('zielid','SHORTNAME');
     $zielart=substr($zielid,0,1);
     $zielid=substr($zielid,1,strlen($zielid)-1);
     $zeiger = @mysql_query("SELECT * FROM $skrupel_sternenbasen where besitzer=$spieler and status=1 and id=$baid");

--- a/inhalt/basen_gamma.php
+++ b/inhalt/basen_gamma.php
@@ -407,10 +407,10 @@ if ($fuid==3) {
     $antriebestufe=int_post('antriebe');
     $projektilestufe=int_post('projektile');
     $energetikstufe=int_post('energetik');
-    $schiffsname=$_POST['schiffsname'];
+    $schiffsname=str_post('schiffsname','SQLSAFE');
     $zusatz=int_post('zusatz');
-    $schiffsname=str_replace("'"," ",$schiffsname);
-    $schiffsname=str_replace('"'," ",$schiffsname);
+    //$schiffsname=str_replace("'"," ",$schiffsname);
+    //$schiffsname=str_replace('"'," ",$schiffsname);
     if ($art!=3) { $zusatz=0; }
     if ($projektilestufe>=1) {} else {$projektilestufe=0;}
     if ($energetikstufe>=1) {} else {$energetikstufe=0;}
@@ -488,7 +488,7 @@ if ($fuid==4) {
     $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_sternenbasen where id=$baid");
     $array = @mysql_fetch_array($zeiger);
     $logbuch=$array["logbuch"];
-    $logbuch=str_replace("\\", "",$logbuch);
+    //$logbuch=str_replace("\\", "",$logbuch);
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0"">
         <center>
@@ -522,9 +522,9 @@ if ($fuid==4) {
 }
 if ($fuid==5) {
     include ("inc.header.php");
-    $eintrag=$_POST["logbuchdaten"];
-    $eintrag=str_replace("\"", "\'",$eintrag);
-    $eintrag=str_replace("\\", "",$eintrag);
+    $eintrag=str_post('logbuchdaten','SQLSAFE');
+    //$eintrag=str_replace("\"", "\'",$eintrag);
+    //$eintrag=str_replace("\\", "",$eintrag);
     $zeiger = @mysql_query("UPDATE $skrupel_sternenbasen set logbuch=\"$eintrag\" where id=$baid");
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0"">

--- a/inhalt/flotte_alpha.php
+++ b/inhalt/flotte_alpha.php
@@ -342,7 +342,7 @@ if ($fuid==2) {
         $zielidf=int_post('zielidf');
         $verbrauchf=int_post('verbrauchf');
         $benzin2=int_post('benzin2');
-        $kursmodus=$_POST["pathfind"];
+        $kursmodus=int_post('pathfind');
         if ($warpfaktor==0) {
             $flug=0;
             $warp=0;
@@ -1767,7 +1767,7 @@ if ($fuid==6) {
     $routing_mins="";
     $routing_id="";
     $routing_koord="";
-    if(urldecode($_POST["submitbutton"]) == utf8_encode(html_entity_decode($lang['flottealpha']['uebernehmen']))){
+    if(urldecode(str_post('submitbutton','DEFAULT')) == utf8_encode(html_entity_decode($lang['flottealpha']['uebernehmen']))){
         for($i=0;$i<int_post('points');$i++){
             if(int_post('pid_'.$i)!=-1){
                 $routing_mins=$routing_mins.int_post('cantox_'.$i).int_post('vorrat_'.$i).int_post('lem_'.$i).int_post('bax_'.$i).int_post('ren_'.$i).int_post('vor_'.$i).int_post('vol_'.$i);
@@ -1840,7 +1840,7 @@ if ($fuid==6) {
                 </tr>
                 <tr>
                     <?php    
-                    if($_POST["submitbutton"]==$lang['flottealpha']['neueroute']){
+                    if(str_post('submitbutton','DEFAULT')==$lang['flottealpha']['neueroute']){
                         ?>
                         <input type="hidden" name="pid_0" value=-1>
                         <input type="hidden" name="cantox_0" value=0>
@@ -1854,7 +1854,7 @@ if ($fuid==6) {
                         <input type="hidden" name="lbt_0" value=0>
                         <input type="hidden" name="sbt_0" value=0>
                         <?php
-                    }elseif($_POST["submitbutton"]==$lang['flottealpha']['routebearbeiten']){
+                    }elseif(str_post('submitbutton','DEFAULT')==$lang['flottealpha']['routebearbeiten']){
                         $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
                         $array = @mysql_fetch_array($zeiger);
                         $routing_id_t=$array["routing_id"];
@@ -1912,7 +1912,7 @@ if ($fuid==6) {
                         $kol_a=substr($routing_mins[$i],7,7);
                         $lbt_a=substr($routing_mins[$i],14,4);
                         $sbt_a=substr($routing_mins[$i],18,4);
-                    }elseif(urldecode($_POST["submitbutton"])==utf8_encode(html_entity_decode($lang['flottealpha']['loeschen']))){
+                    }elseif(urldecode(str_post('submitbutton','DEFAULT'))==utf8_encode(html_entity_decode($lang['flottealpha']['loeschen']))){
                         $point=int_post('point');
                         $points=int_post('points')-1;
                         for($i=0;$i<$point;$i++){
@@ -1964,7 +1964,7 @@ if ($fuid==6) {
                         for($i=0;$i<$points;$i++){
                             $_POST["pid_".$i]=$pid_h[$i];
                         }
-                    }elseif(urldecode($_POST["submitbutton"])==utf8_encode(html_entity_decode($lang['flottealpha']['neuerpunkt']))){
+                    }elseif(urldecode(str_post('submitbutton','DEFAULT'))==utf8_encode(html_entity_decode($lang['flottealpha']['neuerpunkt']))){
                         $point=int_post('point')+1;
                         $points=int_post('points')+1;
                         for($i=0;$i<$point;$i++){
@@ -2019,13 +2019,13 @@ if ($fuid==6) {
                     }else{
                         $point=int_post('point');
                         $points=int_post('points');
-                        if($_POST["submitbutton"]=="<"){
+                        if(str_post('submitbutton','DEFAULT')=='<'){
                             if($point>0){
                                 $point=$point-1;
                             }else{
                                 $point=$points-1;
                             }
-                        }elseif($_POST["submitbutton"]==">"){
+                        }elseif(str_post('submitbutton','DEFAULT')=='>'){
                             if($point<$points-1){
                                 $point=$point+1;
                             }else{
@@ -2073,7 +2073,7 @@ if ($fuid==6) {
                             $danach=0;
                         }
                     }
-                    if($_POST["wechsel"]==$lang['flottealpha']['fracht']){
+                    if(str_post('wechsel','DEFAULT')==$lang['flottealpha']['fracht']){
                         ?>
                         <td style="color:#aaaaaa;"><?php echo $lang['flottealpha']['wegpunkt']; ?> <?php echo $point+1; ?><?php echo $lang['flottealpha']['von']; ?><?php echo $points; ?>&nbsp;</td>
                         <td><select name="pid_<?php echo $point; ?>">
@@ -2153,7 +2153,7 @@ if ($fuid==6) {
                     <input type="submit" value="<" name="submitbutton"><?php if($points>1){?><input type="submit" value="<?php echo $lang['flottealpha']['uebernehmen']; ?>"  name="submitbutton"><?php } if(($points<10) and ($planetenanzahl>0)){?><input type="submit" value="<?php echo $lang['flottealpha']['neuerpunkt']; ?>"  name="submitbutton"><?php }if($points>1){?><input type="submit" value="<?php echo $lang['flottealpha']['loeschen']; ?>"  name="submitbutton"><?php }?><input type="hidden" value="<?php echo $lang['flottealpha']['fracht']; ?>" name="wechsel"><input type="submit" value="<?php echo $lang['flottealpha']['passagiere']; ?>"  name="wechsel"><input type="submit" value=">"  name="submitbutton" >
                 </center>
                 <?php
-            }elseif($_POST["wechsel"]==$lang['flottealpha']['passagiere']){
+            }elseif(str_post('wechsel','DEFAULT')==$lang['flottealpha']['passagiere']){
                 ?>
                 </table>
                 <table border="0" cellspacing="0" cellpadding="1">
@@ -2310,14 +2310,14 @@ if ($fuid==6) {
 }
 if ($fuid==7) {
     include ("inc.header.php");
-    $routing_mins=$_POST["routing_mins"];
-    $routing_id=$_POST["routing_id"];
-    $routing_koord=$_POST["routing_koord"];
+    $routing_mins=str_post('routing_mins','DEFAULT');
+    $routing_id=str_post('routing_id','DEFAULT');
+    $routing_koord=str_post('routing_koord','DEFAULT');
     $zielx=int_post('zielx');
     $ziely=int_post('ziely');
     $zielid=int_post('zielid');
     $flug=int_post('flug');
-    if ($_POST["submitbutton"]==$lang['flottealpha']['routeabschliessen']) {
+    if (str_post('submitbutton','DEFAULT')==$lang['flottealpha']['routeabschliessen']) {
         $zeiger = @mysql_query("SELECT * FROM $skrupel_schiffe where id=$shid");
         $array = @mysql_fetch_array($zeiger);
         $antrieb=$array["antrieb"];
@@ -2424,9 +2424,9 @@ if ($fuid==7) {
 }
 if ($fuid==8) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set routing_id=\"".$_POST["routing_id"]."\",
-                                                     routing_koord=\"".$_POST["routing_koord"]."\",
-                                                     routing_mins=\"".$_POST["routing_mins"]."\",
+    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set routing_id=\"".str_post('routing_id','DEFAULT')."\",
+                                                     routing_koord=\"".str_post('routing_koord','DEFAULT')."\",
+                                                     routing_mins=\"".str_post('routing_mins','DEFAULT')."\",
                                                      routing_status=2,
                                                      routing_schritt=0,
                                                      routing_warp=".int_post('warpfaktor').",

--- a/inhalt/flotte_beta.php
+++ b/inhalt/flotte_beta.php
@@ -2458,7 +2458,7 @@ if ($fuid==8) {
     $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_schiffe where id=$shid");
     $array = @mysql_fetch_array($zeiger);
     $logbuch=$array["logbuch"];
-    $logbuch=str_replace("\\", "",$logbuch);
+    //$logbuch=str_replace("\\", "",$logbuch);
 
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
@@ -2495,9 +2495,9 @@ if ($fuid==8) {
 if ($fuid==9) {
     include ("inc.header.php");
 
-    $eintrag=$_POST["logbuchdaten"];
-    $eintrag=str_replace("\"", "\'",$eintrag);
-    $eintrag=str_replace("\\", "",$eintrag);
+    $eintrag=str_post('logbuchdaten','SQLSAFE');
+    //$eintrag=str_replace("\"", "\'",$eintrag);
+    //$eintrag=str_replace("\\", "",$eintrag);
     $zeiger = @mysql_query("UPDATE $skrupel_schiffe set logbuch=\"$eintrag\" where id=$shid");
 
     ?>

--- a/inhalt/flotte_delta.php
+++ b/inhalt/flotte_delta.php
@@ -296,7 +296,7 @@ if ($fuid==5) {
 }
 if ($fuid==6) {
     include ("inc.header.php");
-    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set name=\"".$_POST["schiffname"]."\" where id=$shid and besitzer=$spieler");
+    $zeiger = @mysql_query("UPDATE $skrupel_schiffe set name=\"".str_post('schiffname','SQLSAFE')."\" where id=$shid and besitzer=$spieler");
     ?>
     <body text="#000000" background="<?php echo $bildpfad; ?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <br><br><br><br>

--- a/inhalt/hilfe_schiff.php
+++ b/inhalt/hilfe_schiff.php
@@ -9,7 +9,7 @@ if ($fuid>=1) {
     ?>
 <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
 <?php
-    $volk=$_GET["volk"];
+    $volk=str_get('volk','SHORTNAME');
     $file='../daten/'.$volk.'/schiffe.txt';
     $fp = @fopen("$file","r");
     if($fp){
@@ -374,7 +374,7 @@ if ($fuid>=1) {
                 <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad; ?>" target="_self">
             </frameset>
-            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_schiff.php?fu=<?php echo int_get('fu2'); ?>&volk=<?php echo $_GET["volk"]; ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
+            <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="hilfe_schiff.php?fu=<?php echo int_get('fu2'); ?>&volk=<?php echo str_get('volk','SHORTNAME'); ?>&uid=<?php echo $uid; ?>&sid=<?php echo $sid; ?>" target="_self">
             <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                 <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad; ?>" target="_self">
                 <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad; ?>" target="_self">

--- a/inhalt/inc.check.php
+++ b/inhalt/inc.check.php
@@ -4,8 +4,8 @@
 */
 //$_POST  = @array_map('mysql_real_escape_string', $_POST);
 //$_GET = @array_map('mysql_real_escape_string', $_GET);
-$sid = (isset($_GET['sid'])?$_GET['sid']:0);
-$uid = (isset($_GET['uid'])?$_GET['uid']:0);
+$sid = (isset($_GET['sid']) && !preg_match('/[^0-9A-Za-z]/',$_GET['sid']))?$_GET['sid']:0;
+$uid = (isset($_GET['uid']) && !preg_match('/[^0-9A-Za-z]/',$_GET['uid']))?$_GET['uid']:0;
 $zeiger = @mysql_query("SELECT * FROM $skrupel_user where uid='$uid'");
 $datensaetze = @mysql_num_rows($zeiger);
 if ($datensaetze==1) {

--- a/inhalt/inc.hilfsfunktionen.php
+++ b/inhalt/inc.hilfsfunktionen.php
@@ -29,20 +29,60 @@ function int_get($key) {
     }
     return false;
 }
-function str_post($key) {
-    //todo, optionales escapen?
-    if(isset($_POST[$key])) {
-        if(strlen($_POST[$key]) > 0) {
-            return $_POST[$key];
+function str_post($key,$mode) {
+    if (isset($_POST[$key]) and !is_array($_POST[$key])) {
+        if ($mode=='DEFAULT') {
+            if (!preg_match('/[^0-9A-Za-z_&:;\-]/',$_POST[$key])) {
+                return $_POST[$key];
+            }
+        }
+        if ($mode=='PATHNAME') {
+            if (!preg_match('/[^0-9A-Za-z_\/\.]/',$_POST[$key])) {
+                return $_POST[$key];
+            }
+        }
+        if ($mode=='SHORTNAME') {
+            if (!preg_match('/[^0-9A-Za-z_]/',$_POST[$key])) {
+                return $_POST[$key];
+            }
+        }
+        if ($mode=='SQLSAFE') {
+            $retvar = stripslashes($_POST[$key]);
+            if ($key=='thema' || $key=='beitrag' || $key=='offenbarung') {
+                $retvar = nl2br($retvar);
+            }
+            //$retvar = strtr($retvar, array("\x00" => "\\x00", "\x1a" => "\\x1a", "\n" => "\\n", "\r" => "\\r", "\\" => "\\\\", "'" => "\'", "\"" => "\\\"")); // nur escapen
+            $retvar = strtr($retvar, array("\x00" => "\\x00", "\x1a" => "\\x1a", "\n" => "\\n", "\r" => "\\r", "\\" => "", "'" => "", "\"" => "")); // entfernt: " ' \
+            return $retvar;
         }
     }
     return false;
 }
-function str_get($key) {
-    //todo, optionales escapen?
-    if(isset($_GET[$key])) {
-        if(strlen($_GET[$key]) > 0) {
-            return $_GET[$key];
+function str_get($key,$mode) {
+    if (isset($_GET[$key]) and !is_array($_GET[$key])) {
+        if ($mode=='DEFAULT') {
+            if (!preg_match('/[^0-9A-Za-z_&:;\-]/',$_GET[$key])) {
+                return $_GET[$key];
+            }
+        }
+        if ($mode=='PATHNAME') {
+            if (!preg_match('/[^0-9A-Za-z_\/\.]/',$_GET[$key])) {
+                return $_GET[$key];
+            }
+        }
+        if ($mode=='SHORTNAME') {
+            if (!preg_match('/[^0-9A-Za-z_]/',$_GET[$key])) {
+                return $_GET[$key];
+            }
+        }
+        if ($mode=='SQLSAFE') {
+            $retvar = stripslashes($_GET[$key]);
+            if ($key=='thema' || $key=='beitrag' || $key=='offenbarung') {
+                $retvar = nl2br($retvar);
+            }
+            //$retvar = strtr($retvar, array("\x00" => "\\x00", "\x1a" => "\\x1a", "\n" => "\\n", "\r" => "\\r", "\\" => "\\\\", "'" => "\'", "\"" => "\\\"")); // nur escapen
+            $retvar = strtr($retvar, array("\x00" => "\\x00", "\x1a" => "\\x1a", "\n" => "\\n", "\r" => "\\r", "\\" => "", "'" => "", "\"" => "")); // entfernt: " ' \
+            return $retvar;
         }
     }
     return false;

--- a/inhalt/inc.host_messenger.php
+++ b/inhalt/inc.host_messenger.php
@@ -22,12 +22,12 @@ if ($fuu==1) {
         }
     }
 }
-if ($_GET["fu"]==2) {
+if (intval($_GET["fu"])==2) {
     include ("../inc.conf.php");
     $sname=$_GET["sname"];
     $jab=$_GET["jab"];
     $hash=$_GET["hash"];
-    $msg=str_replace('{1}',$sname,$lang['hostmessenger'][$spielersprache[$_GET["k"]]][0]);
+    $msg=str_replace('{1}',$sname,$lang['hostmessenger'][$spielersprache[intval($_GET["k"])]][0]);
     ignore_user_abort(true);
     $url="http://".$_SERVER['SERVER_NAME'].$_SERVER['SCRIPT_NAME'];
     $url=substr($url,0,strlen($url)-30);

--- a/inhalt/kommunikation_board.php
+++ b/inhalt/kommunikation_board.php
@@ -657,20 +657,20 @@ if ($fuid==4) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $forum=int_get('forum');
-    $icon=$_POST["icon"];
+    $icon=int_post('icon');
     include ("inc.check.php");
     $beginner=$spieler_name;
     $letzter=time();
-    $thema=$_POST["thema"];
-    $beitrag=$_POST["beitrag"];
-    $beitrag=nl2br(stripslashes($beitrag));
-    $beitrag=str_replace("'", "",$beitrag);
-    $beitrag=str_replace("\"", "",$beitrag);
-    $beitrag=str_replace("\\", "",$beitrag);
-    $thema=nl2br(stripslashes($thema));
-    $thema=str_replace("'", "",$thema);
-    $thema=str_replace("\"", "",$thema);
-    $thema=str_replace("\\", "",$thema);
+    $thema=str_post('thema','SQLSAFE');
+    $beitrag=str_post('beitrag','SQLSAFE');
+    //$beitrag=nl2br(stripslashes($beitrag));
+    //$beitrag=str_replace("'", "",$beitrag);
+    //$beitrag=str_replace("\"", "",$beitrag);
+    //$beitrag=str_replace("\\", "",$beitrag);
+    //$thema=nl2br(stripslashes($thema));
+    //$thema=str_replace("'", "",$thema);
+    //$thema=str_replace("\"", "",$thema);
+    //$thema=str_replace("\\", "",$thema);
     $zeiger = @mysql_query("INSERT INTO $skrupel_forum_thema (forum,icon,thema,beginner,antworten,letzter) values ($forum,$icon,'$thema','$beginner',0,'$letzter');");
     $zeiger = @mysql_query("SELECT * FROM $skrupel_forum_thema where forum=$forum and icon=$icon and beginner='$beginner' and thema='$thema' and letzter='$letzter' and antworten=0;");
     $array = @mysql_fetch_array($zeiger);
@@ -683,7 +683,7 @@ if ($fuid==4) {
 if ($fuid==3) {
     include ("inc.header.php");
     $forum=int_get('fo');
-    $thema=$_GET["thema"];
+    $thema=int_get('thema');
     if ($forum==1) { $formname=$lang['kommunikationboard']['offenbarungen'];}
     if ($forum==2) { $formname=$lang['kommunikationboard']['smalltalk'];}
     if ($forum==3) { $formname=$lang['kommunikationboard']['handel'];}
@@ -888,16 +888,16 @@ if ($fuid==5) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
     $db = @mysql_select_db("$database",$conn);
     $forum=int_get('forum');
-    $thema=$_GET["thema"];
-    $icon=$_POST["icon"];
+    $thema=int_get('thema');
+    $icon=int_post('icon');
     include ("inc.check.php");
     $beginner=$spieler_name;
     $letzter=time();
-    $beitrag=$_POST["beitrag"];
-    $beitrag=nl2br(stripslashes($beitrag));
-    $beitrag=str_replace("'", "",$beitrag);
-    $beitrag=str_replace("\"", "",$beitrag);
-    $beitrag=str_replace("\\", "",$beitrag);
+    $beitrag=str_post('beitrag','SQLSAFE');
+    //$beitrag=nl2br(stripslashes($beitrag));
+    //$beitrag=str_replace("'", "",$beitrag);
+    //$beitrag=str_replace("\"", "",$beitrag);
+    //$beitrag=str_replace("\\", "",$beitrag);
     $zeiger = mysql_query("INSERT INTO $skrupel_forum_beitrag (thema,forum,datum,beitrag,verfasser,spielerid) values ($thema,$forum,'$letzter','$beitrag','$beginner',$spieler);");
     $zeiger = mysql_query("UPDATE $skrupel_forum_thema set antworten=antworten+1,letzter='$letzter' where id=$thema;");
     @mysql_close();

--- a/inhalt/kommunikation_ch.php
+++ b/inhalt/kommunikation_ch.php
@@ -23,10 +23,10 @@ if ($fuid==2) {
     $array = @mysql_fetch_array($zeiger);
     $spieler_chatfarbe = $array["chatfarbe"];
     $spieler_id = $array["id"];
-    if (strlen($_POST["nachricht"])>=1) {
+    if (strlen(str_post('nachricht','SQLSAFE'))>=1) {
         $aktuell=time();
         $farbe=$spieler_chatfarbe;
-        $nachricht=$_POST["nachricht"];
+        $nachricht=str_post('nachricht','SQLSAFE');
         function iif ($expression,$returntrue,$returnfalse) {
             if ($expression==0) {
                 return $returnfalse;
@@ -76,7 +76,8 @@ if ($fuid==2) {
             $bbcode=str_replace("Ä","&Auml;",$bbcode);
             $bbcode=str_replace("Ö","&Ouml;",$bbcode);
             $bbcode=str_replace("Ü","&Uuml;",$bbcode);
-            $bbcode=nl2br($bbcode);
+            //$bbcode=nl2br($bbcode);
+            $bbcode=strtr($bbcode, array("\\r\\n" => "<br />\\r\\n", "\\r" => "<br />\\r", "\\n" => "<br />\\n"));
             $bbcode=eregi_replace(quotemeta("[b]"),quotemeta("<b>"),$bbcode);
             $bbcode=eregi_replace(quotemeta("[/b]"),quotemeta("</b>"),$bbcode);
             $bbcode=eregi_replace(quotemeta("[i]"),quotemeta("<i>"),$bbcode);
@@ -124,11 +125,11 @@ if ($fuid==2) {
         }
         $aktuell=time();
         $farbe=$spieler_chatfarbe;
-        $nachricht=$_POST["nachricht"];
-        $nachricht=nl2br(stripslashes($nachricht));
-        $nachricht=str_replace("'", "",$nachricht);
+        $nachricht=str_post('nachricht','SQLSAFE');
+        //$nachricht=nl2br(stripslashes($nachricht));
+        //$nachricht=str_replace("'", "",$nachricht);
         //$nachricht=str_replace("\"", "",$nachricht);
-        $nachricht=str_replace("\\", "",$nachricht);
+        //$nachricht=str_replace("\\", "",$nachricht);
         //$nachricht=str_replace("\;", "",$nachricht);
         //$nachricht=str_replace("\n", "",$nachricht);
         $nachricht=parsetext($nachricht);
@@ -137,10 +138,10 @@ if ($fuid==2) {
         $an=int_post('an');
         $zeiger = @mysql_query("INSERT INTO $skrupel_chat (spiel,datum,text,an,von,farbe) values ($spiel,'$aktuell','$nachricht','$an','$spieler_name','$farbe');");
     }
-    if (strlen($_GET["zeit"])>=1) {
+    if (int_get('zeit')>=1) {
         $neutext="";
         $textn="";
-        $datumzeit=$_GET["zeit"];
+        $datumzeit=int_get('zeit');
         $zeiger = @mysql_query("SELECT * FROM $skrupel_chat where datum>$datumzeit and (an=0 or an=$spieler_id) order by datum");
         $chatanzahl = @mysql_num_rows($zeiger);
         if ($chatanzahl>=1) {
@@ -162,7 +163,7 @@ if ($fuid==2) {
                 $neuzeit=$datumn;
             }
         } else { 
-            $neuzeit=$_GET["zeit"];
+            $neuzeit=int_get('zeit');
         }
         ?>
         <script language=JavaScript>
@@ -218,7 +219,7 @@ if ($fuid==2) {
                                     <select name="an" style="width:75px;">
                                         <option value="0"><?php echo str_replace('{1}',$lang['kommunikationch']['alle'],$lang['kommunikationch']['an'])?></option>
                                         <?php
-                                        $zeiger = @mysql_query("SELECT * FROM $skrupel_user WHERE uid<>'".$_GET["uid"]."' order by nick");
+                                        $zeiger = @mysql_query("SELECT * FROM $skrupel_user WHERE uid<>'".$uid."' order by nick");
                                         $user_anzahl = @mysql_num_rows($zeiger);
                                         for  ($i=0; $i<$user_anzahl;$i++) {
                                             $ok = @mysql_data_seek($zeiger,$i);
@@ -227,7 +228,7 @@ if ($fuid==2) {
                                             $user_id=$array["id"];
                                             $spielerchatfarbe=$array["chatfarbe"];
                                             ?>
-                                            <option value="<?php echo $user_id; ?>" style="color:#<?php echo $spielerchatfarbe?>;" <?php if($_POST["an"]==$user_id) echo "selected";?> ><?php echo str_replace('{1}',$nick,$lang['kommunikationch']['an'])?></option>
+                                            <option value="<?php echo $user_id; ?>" style="color:#<?php echo $spielerchatfarbe?>;" <?php if(int_post('an')==$user_id) echo "selected";?> ><?php echo str_replace('{1}',$nick,$lang['kommunikationch']['an'])?></option>
                                             <?php
                                         }
                                         ?>

--- a/inhalt/kommunikation_exch.php
+++ b/inhalt/kommunikation_exch.php
@@ -3,8 +3,8 @@ include ('../inc.conf.php');
 include_once ('inc.hilfsfunktionen.php');
 $langfile_1 = 'kommunikation_exch';
 $fuid = int_get('fu');
-$uid=$_GET["uid"];
-$sid=$_GET["sid"];
+$sid = (isset($_GET['sid']) && !preg_match('/[^0-9A-Za-z]/',$_GET['sid']))?$_GET['sid']:0;
+$uid = (isset($_GET['uid']) && !preg_match('/[^0-9A-Za-z]/',$_GET['uid']))?$_GET['uid']:0;
 
 if ($fuid==1) {
     $conn = @mysql_connect($server.':'.$port,"$login","$password");
@@ -131,7 +131,7 @@ if ($fuid==3) {
                 }
             </style>
             <?php
-            if (strlen($_POST["nachricht"])>=1) {
+            if (strlen(str_post('nachricht','SQLSAFE'))>=1) {
                 function iif ($expression,$returntrue,$returnfalse) {
                     if ($expression==0) {
                         return $returnfalse;
@@ -181,7 +181,8 @@ if ($fuid==3) {
                     $bbcode=str_replace("Ä","&Auml;",$bbcode);
                     $bbcode=str_replace("Ö","&Ouml;",$bbcode);
                     $bbcode=str_replace("Ü","&Uuml;",$bbcode);
-                    $bbcode=nl2br($bbcode);
+                    //$bbcode=nl2br($bbcode);
+                    $bbcode=strtr($bbcode, array("\\r\\n" => "<br />\\r\\n", "\\r" => "<br />\\r", "\\n" => "<br />\\n"));
                     $bbcode=eregi_replace(quotemeta("[b]"),quotemeta("<b>"),$bbcode);
                     $bbcode=eregi_replace(quotemeta("[/b]"),quotemeta("</b>"),$bbcode);
                     $bbcode=eregi_replace(quotemeta("[i]"),quotemeta("<i>"),$bbcode);
@@ -228,17 +229,17 @@ if ($fuid==3) {
                 }
                 $aktuell=time();
                 $farbe=$spieler_chatfarbe;
-                $nachricht=$_POST["nachricht"];
-                $nachricht=nl2br(stripslashes($nachricht));
-                $nachricht=str_replace("'", "",$nachricht);
-                $nachricht=str_replace("\\", "",$nachricht);
+                $nachricht=str_post('nachricht','SQLSAFE');
+                //$nachricht=nl2br(stripslashes($nachricht));
+                //$nachricht=str_replace("'", "",$nachricht);
+                //$nachricht=str_replace("\\", "",$nachricht);
                 $nachricht=parsetext($nachricht);
                 $jetzt=date("H:i",$aktuell);
                 //$text="<table border=\"0\" cellspacing=\"0\" cellpadding=\"0\"><tr><td valign=\"top\" style=\"color:$farbe;\"><nobr>$spieler_name&nbsp;</nobr></td><td valign=\"top\" style=\"color:#aaaaaa;\"><nobr>@ $jetzt&nbsp;</nobr></td><td valign=\"top\">$nachricht</td></tr></table>";
                 $an=int_post('an');
                 $zeiger = @mysql_query("INSERT INTO $skrupel_chat (spiel,datum,text,an,von,farbe) values (1,'$aktuell','$nachricht','$an','$spieler_name','$farbe');");
             }
-            if (strlen($_GET["zeit"])>=1) { } else { $neuzeit=time();$first=1;}
+            if (int_get('zeit')>=1) { } else { $neuzeit=time();$first=1;}
             ?>
             <script language="JavaScript">
                 function senden(e) {
@@ -411,10 +412,10 @@ if ($fuid==5) {
                 }
             </style>
             <?php
-            if (strlen($_GET["zeit"])>=1) {
+            if (int_get('zeit')>=1) {
                 $neutext="";
                 $textn="";
-                $datumzeit=$_GET["zeit"];
+                $datumzeit=int_get('zeit');
                 $zeiger = @mysql_query("SELECT * FROM $skrupel_chat where datum>$datumzeit and (an=0 or an=$spieler_id) order by datum");
                 $chatanzahl = @mysql_num_rows($zeiger);
                 if ($chatanzahl>=1) {
@@ -434,7 +435,7 @@ if ($fuid==5) {
                         $neutext=$neutext.$textn;
                         $neuzeit=$datumn;
                     }
-                } else { $neuzeit=$_GET["zeit"]; }
+                } else { $neuzeit=int_get('zeit'); }
                 ?>
                 <script language=JavaScript>
                     var ant=parent.contentFrame.chatinhalt.document.getElementById('chattext');
@@ -566,7 +567,7 @@ if ($fuid==6) {
                         <select name="an">
                             <option value="0"><?php echo $lang['kommunikationexch']['allemitspieler']; ?></option>
                             <?php
-                            $zeiger = @mysql_query("SELECT * FROM $skrupel_user WHERE uid<>'".$_GET["uid"]."' order by nick");
+                            $zeiger = @mysql_query("SELECT * FROM $skrupel_user WHERE uid<>'".$uid."' order by nick");
                             $user_anzahl = @mysql_num_rows($zeiger);
                             for  ($i=0; $i<$user_anzahl;$i++) {
                                 $ok = @mysql_data_seek($zeiger,$i);

--- a/inhalt/kommunikation_politik.php
+++ b/inhalt/kommunikation_politik.php
@@ -273,7 +273,7 @@ if ($fuid==4) {
     include ("inc.header.php");
     $art = int_post('art');
     $spielernummer = int_post('spielernummer');
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$sid."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
     $spielertemp=$sprachtemp_1["spieler_".$spielernummer];
@@ -527,7 +527,7 @@ if ($fuid==5) {
     include ("inc.header.php");
     $art = int_post('art');
     $spielernummer = int_post('spieler2');
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$sid."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
     $spielertemp=$sprachtemp_1["spieler_".$spielernummer];
@@ -638,7 +638,7 @@ if ($fuid==6) {
     include ("inc.header.php");
     $art = int_post('art');
     $spielernummer = int_post('spieler2');
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
+    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$sid."'");
     $ok = @mysql_data_seek($zeiger,0);
     $sprachtemp_1 = @mysql_fetch_array($zeiger);
     $spielertemp=$sprachtemp_1["spieler_".$spielernummer];

--- a/inhalt/kommunikation_subfunk.php
+++ b/inhalt/kommunikation_subfunk.php
@@ -86,7 +86,7 @@ if ($fuid==1) {
                 </tr>
                 <tr height="100%">
                     <td></td>
-                    <td><textarea name="nachricht" style="width:100%;height:100%;"><?php echo $_POST["nachricht"]?></textarea></td>
+                    <td><textarea name="nachricht" style="width:100%;height:100%;"><?php echo str_post('nachricht','SQLSAFE')?></textarea></td>
                     <td></td>
                 </tr>
                 <tr>
@@ -116,24 +116,17 @@ if ($fuid==1) {
     @mysql_close();
 }
 if ($fuid==2) {
-    $conn = @mysql_connect($server.':'.$port,"$login","$password");
-    $db = @mysql_select_db("$database",$conn);
-    $spielernummer=int_post('empfang');
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
-    $ok = @mysql_data_seek($zeiger,0);
-    $sprachtemp_1 = @mysql_fetch_array($zeiger);
-    $spielertemp=$sprachtemp_1["spieler_".$spielernummer];
-    $zeiger=@mysql_query("SELECT sprache FROM $skrupel_user where id=$spielertemp");
-    $ok = @mysql_data_seek($zeiger,0);
-    $sprachtemp_2 = @mysql_fetch_array($zeiger);
-    $spieler2sprache=($sprachtemp_2["sprache"]=='')?$language:$sprachtemp_2["sprache"];
-    $file="../lang/".$spieler2sprache."/lang.kommunikation_subfunk_b.php";
-    include($file);
     include ("inc.header.php");
+    $spielernummer = int_post('empfang');
+    $spielertemp = $spieler_id_c[$spielernummer];
+    $zeiger = @mysql_query("SELECT sprache FROM $skrupel_user where id=$spielertemp");
+    $array = @mysql_fetch_array($zeiger);
+    $spieler2sprache = ($array['sprache']=='')?$language:$array['sprache'];
+    include('../lang/'.$spieler2sprache.'/lang.kommunikation_subfunk_b.php');
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
     <?php
-    $nachricht=$_POST["nachricht"];
+    $nachricht=str_post('nachricht','SQLSAFE');
     function iif ($expression,$returntrue,$returnfalse) {
         if ($expression==0) {
             return $returnfalse;
@@ -183,7 +176,8 @@ if ($fuid==2) {
         $bbcode=str_replace("Ä","&Auml;",$bbcode);
         $bbcode=str_replace("Ö","&Ouml;",$bbcode);
         $bbcode=str_replace("Ü","&Uuml;",$bbcode);
-        $bbcode=nl2br($bbcode);
+        //$bbcode=nl2br($bbcode);
+        $bbcode=strtr($bbcode, array("\\r\\n" => "<br />\\r\\n", "\\r" => "<br />\\r", "\\n" => "<br />\\n"));
         $bbcode=eregi_replace(quotemeta("[b]"),quotemeta("<b>"),$bbcode);
         $bbcode=eregi_replace(quotemeta("[/b]"),quotemeta("</b>"),$bbcode);
         $bbcode=eregi_replace(quotemeta("[i]"),quotemeta("<i>"),$bbcode);
@@ -197,7 +191,7 @@ if ($fuid==2) {
             "/(\[)(email)(])(.*)(\[\/email\])/esiU"
         );
         $replacearray = array(
-                "checkurl('\\5', '\\7')",
+            "checkurl('\\5', '\\7')",
             "checkurl('\\4')",
             "checkmail('\\5', '\\7')",
             "checkmail('\\4')"
@@ -228,8 +222,8 @@ if ($fuid==2) {
         $bbcode2=$bbcode;
         return $bbcode2;
     }
-    $nachricht=str_replace("'", "",$nachricht);
-    $nachricht=str_replace("\\", "",$nachricht);
+    //$nachricht=str_replace("'", "",$nachricht);
+    //$nachricht=str_replace("\\", "",$nachricht);
     $nachricht=str_replace("::::::", ":::::",$nachricht);
     $nachricht=parsetext($nachricht);
     $nachricht_org=$nachricht;
@@ -361,23 +355,16 @@ if ($fuid==4) {
 }
 if ($fuid==5) {
     include ("inc.header.php");
-    $conn = @mysql_connect($server.':'.$port,"$login","$password");
-    $db = @mysql_select_db("$database",$conn);
-    $spielernummer=int_post('empfang');
-    $zeiger = @mysql_query("SELECT * FROM $skrupel_spiele where sid='".$_GET["sid"]."'");
-    $ok = @mysql_data_seek($zeiger,0);
-    $sprachtemp_1 = @mysql_fetch_array($zeiger);
-    $spielertemp=$sprachtemp_1["spieler_".$spielernummer];
-    $zeiger=@mysql_query("SELECT sprache FROM $skrupel_user where id=$spielertemp");
-    $ok = @mysql_data_seek($zeiger,0);
-    $sprachtemp_2 = @mysql_fetch_array($zeiger);
-    $spieler2sprache=($sprachtemp_2["sprache"]=='')?$language:$sprachtemp_2["sprache"];
-    $file="../lang/".$spieler2sprache."/lang.kommunikation_subfunk_b.php";
-    include($file);
+    $spielernummer = int_post('empfang');
+    $spielertemp = $spieler_id_c[$spielernummer];
+    $zeiger = @mysql_query("SELECT sprache FROM $skrupel_user where id=$spielertemp");
+    $array = @mysql_fetch_array($zeiger);
+    $spieler2sprache = ($array['sprache']=='')?$language:$array['sprache'];
+    include('../lang/'.$spieler2sprache.'/lang.kommunikation_subfunk_b.php');
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $nachricht=$_POST["nachricht"];
+        $nachricht=str_post('nachricht','SQLSAFE');
         function iif ($expression,$returntrue,$returnfalse) {
             if ($expression==0) {
                 return $returnfalse;
@@ -427,7 +414,8 @@ if ($fuid==5) {
             $bbcode=str_replace("Ä","&Auml;",$bbcode);
             $bbcode=str_replace("Ö","&Ouml;",$bbcode);
             $bbcode=str_replace("Ü","&Uuml;",$bbcode);
-            $bbcode=nl2br($bbcode);
+            //$bbcode=nl2br($bbcode);
+            $bbcode=strtr($bbcode, array("\\r\\n" => "<br />\\r\\n", "\\r" => "<br />\\r", "\\n" => "<br />\\n"));
             $bbcode=eregi_replace(quotemeta("[b]"),quotemeta("<b>"),$bbcode);
             $bbcode=eregi_replace(quotemeta("[/b]"),quotemeta("</b>"),$bbcode);
             $bbcode=eregi_replace(quotemeta("[i]"),quotemeta("<i>"),$bbcode);
@@ -472,8 +460,8 @@ if ($fuid==5) {
             $bbcode2=$bbcode;
             return $bbcode2;
         }
-        $nachricht=str_replace("'", "",$nachricht);
-        $nachricht=str_replace("\\", "",$nachricht);
+        //$nachricht=str_replace("'", "",$nachricht);
+        //$nachricht=str_replace("\\", "",$nachricht);
         $nachricht=str_replace("::::::", ":::::",$nachricht);
         $nachricht=parsetext($nachricht);
         $nachricht=str_replace(array('{1}','{2}','{3}'),array($spielerfarbe[$spieler], $spieler_name, $nachricht),$spieler."::::::".$lang['kommunikationsubfunk_b']['nachricht']);

--- a/inhalt/meta_fordner.php
+++ b/inhalt/meta_fordner.php
@@ -160,8 +160,8 @@ if ($fuid==2) {
     ?>
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
-        $ordnerneu=$_POST["ordnerneu"];
-        $ordnerneu=addslashes($ordnerneu);
+        $ordnerneu=str_post('ordnerneu','SQLSAFE');
+        //$ordnerneu=addslashes($ordnerneu);
         $zeiger_temp = @mysql_query("INSERT INTO $skrupel_ordner (name,besitzer,spiel) values ('$ordnerneu',$spieler,$spiel)");
         ?>
         <script language=JavaScript>
@@ -176,8 +176,8 @@ if ($fuid==3) {
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
         $ooid=int_get('ooid');
-        $ordnerneu=$_POST["ordnerneu"];
-        $ordnerneu=addslashes($ordnerneu);
+        $ordnerneu=str_post('ordnerneu','SQLSAFE');
+        //$ordnerneu=addslashes($ordnerneu);
         $zeiger_temp = @mysql_query("UPDATE $skrupel_ordner set name='$ordnerneu' where id =$ooid");
         ?>
         <script language=JavaScript>
@@ -207,7 +207,7 @@ if ($fuid==5) {
     <body text="#000000" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <?php
         $ooid=int_get('ooid');
-        $icon=$_POST["icon"];
+        $icon=int_post('icon');
         $zeiger_temp = @mysql_query("UPDATE $skrupel_ordner set icon='$icon' where id =$ooid");
         ?>
         <script language=JavaScript>

--- a/inhalt/meta_optionen.php
+++ b/inhalt/meta_optionen.php
@@ -275,14 +275,14 @@ if ($fuid==2) {
     <body text="#000000" bgcolor="#444444"  link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <div id="bodybody" class="flexcroll" onfocus="this.blur()">
         <?php
-        $sprache=$_POST['sprache'];
-        $email=$_POST['email'];
-        $icq=$_POST['icq'];
-        $jabber=$_POST['jabber'];
-        $avatar=$_POST['avatar'];
-        $chatfarbe=$_POST['chatfarbe'];
+        $sprache=str_post('sprache','SHORTNAME');
+        $email=str_post('email','SQLSAFE');
+        $icq=str_post('icq','SQLSAFE');
+        $jabber=str_post('jabber','SQLSAFE');
+        $avatar=str_post('avatar','SQLSAFE');
+        $chatfarbe=str_post('chatfarbe','SHORTNAME');
         $passwortneu='';
-        $passwortneu=$_POST['passwortneu'];
+        $passwortneu=str_post('passwortneu','SQLSAFE');
         $optionen='';
         if (int_post('email_nach')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }
         if (int_post('icq_nach')==1) { $optionen=$optionen.'1'; } else { $optionen=$optionen.'0'; }

--- a/inhalt/meta_rassen.php
+++ b/inhalt/meta_rassen.php
@@ -52,8 +52,9 @@ if ($fuid==1) {
 }
 if ($fuid==2) {
     include ("inc.header.php");
-    $rasse=$_GET["rasse"];
-    if ((!strstr($rasse, '.')) and (!strstr($rasse, '/'))) {
+    $rasse = str_get('rasse','SHORTNAME');
+    //if ((!strstr($rasse, '.')) and (!strstr($rasse, '/'))) {
+    if ($rasse!='') {
     ?>
     <script type="text/javascript" src="js/helpers/swfobject.js"></script>
     <body text="#ffffff" bgcolor="#444444" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/osys_spionage.php
+++ b/inhalt/osys_spionage.php
@@ -333,9 +333,9 @@ if ($fuid==3) {
                             $lichtjahre1 = $lichtjahre2;
                         }
                     }
-                    $schiffsname=$_POST['schiffsname'];
-                    $schiffsname=str_replace("'"," ",$schiffsname);
-                    $schiffsname=str_replace('"'," ",$schiffsname);
+                    $schiffsname=str_post('schiffsname','SQLSAFE');
+                    //$schiffsname=str_replace("'"," ",$schiffsname);
+                    //$schiffsname=str_replace('"'," ",$schiffsname);
                     $extra = $spion_daten[$si]['erfahrung']."-init-".$planet['x_pos'].",".$planet['y_pos']."-0";
                     $schiff = $spion_daten[$si]['schiff'];
                     //0name:1kid:2tlvl:3bild:4bildk:5ctx:6mi1:7mi2:8mi3:9waf1:10waf2:11waf3:12fra:13tan:14antr:15cre:16ma:17fert:18beschr

--- a/inhalt/planeten_alpha.php
+++ b/inhalt/planeten_alpha.php
@@ -343,9 +343,9 @@ if ($fuid==3) {
                 $min1=$min1-$kosten[3];
                 $min2=$min2-$kosten[4];
                 $min3=$min3-$kosten[5];
-                $stationsname=$_POST['stationsname'];
-                $stationsname=str_replace("'"," ",$stationsname);
-                $stationsname=str_replace('"'," ",$stationsname);
+                $stationsname=str_post('stationsname','SQLSAFE');
+                //$stationsname=str_replace("'"," ",$stationsname);
+                //$stationsname=str_replace('"'," ",$stationsname);
                 $zeiger_temp = @mysql_query("INSERT INTO $skrupel_sternenbasen (art,status,name,x_pos,y_pos,rasse,planetid,besitzer,spiel,t_huelle,t_antrieb,t_energie,t_explosiv) values ($art,0,'$stationsname',$x_pos,$y_pos,'$spieler_rasse',$pid,$spieler,$spiel,$native_fert_tech_1,$native_fert_tech_2,$native_fert_tech_3,$native_fert_tech_4);");
                 $zeiger_temp = @mysql_query("SELECT id,planetid FROM $skrupel_sternenbasen where planetid=$pid");
                 $array_temp = @mysql_fetch_array($zeiger_temp);

--- a/inhalt/planeten_beta.php
+++ b/inhalt/planeten_beta.php
@@ -111,7 +111,7 @@ if ($fuid==2) {
     $zeiger = @mysql_query("SELECT id,logbuch FROM $skrupel_planeten where id=".$pid);
     $array = @mysql_fetch_array($zeiger);
     $logbuch=$array["logbuch"];
-    $logbuch=str_replace("\\", "",$logbuch);
+    //$logbuch=str_replace("\\", "",$logbuch);
     ?>
     <body text="#000000" background="<?php echo $bildpfad?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">
         <center>
@@ -145,9 +145,9 @@ if ($fuid==2) {
 }
 if ($fuid==3) {
     include ("inc.header.php");
-    $eintrag=$_POST["logbuchdaten"];
-    $eintrag=str_replace("\"", "\'",$eintrag);
-    $eintrag=str_replace("\\", "",$eintrag);
+    $eintrag=str_post('logbuchdaten','SQLSAFE');
+    //$eintrag=str_replace("\"", "\'",$eintrag);
+    //$eintrag=str_replace("\\", "",$eintrag);
     $zeiger = @mysql_query("UPDATE $skrupel_planeten set logbuch=\"$eintrag\" where id=".$pid);
     ?>
     <body text="#000000" background="<?php echo $bildpfad?>/aufbau/14.gif" bgcolor="#000000" link="#000000" vlink="#000000" alink="#000000" leftmargin="0" rightmargin="0" topmargin="0" marginwidth="0" marginheight="0">

--- a/inhalt/runde_ende.php
+++ b/inhalt/runde_ende.php
@@ -1,11 +1,14 @@
 <?php 
 include ('../inc.conf.php');
 include_once ('inc.hilfsfunktionen.php');
-if(empty($_GET['sprache'])){$_GET['sprache']=$language;}
-$file="../lang/".$_GET['sprache']."/lang.runde_ende.php";
-include ($file);
-if (($_GET["bildpfad"]=="bilder") or ($_GET["bildpfad"]=="")) {$_GET["bildpfad"]="../bilder";}
-$bildpfad = $_GET["bildpfad"];
+
+$sprache = str_get('sprache','SHORTNAME');
+if ($sprache=='' || !preg_match('/^[a-z]{2}$/', $sprache) || !is_dir('../lang/'.$sprache)) {$sprache = $language;}
+include ('../lang/'.$sprache.'/lang.runde_ende.php');
+
+$bildpfad = str_get('bildpfad','PATHNAME');
+if ($bildpfad=='' or $bildpfad=='bilder') {$bildpfad='../bilder';}
+
 $spiel = int_get('spiel');
 $fuid = int_get('fu');
 
@@ -40,7 +43,7 @@ if ($fuid==1) {
                     <frame name="rahmen16" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=26&bildpfad=<?php echo $bildpfad?>" target="_self">
                     <frame name="rahmen17" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=27&bildpfad=<?php echo $bildpfad?>" target="_self">
                 </frameset>
-                <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="runde_ende.php?fu=2&spiel=<?php echo $spiel?>&bildpfad=<?php echo $bildpfad?>&sprache=<?php echo $_GET['sprache']?>" target="_self">
+                <frame name="rahmen12" scrolling="auto" marginwidth="0" marginheight="0" noresize src="runde_ende.php?fu=2&spiel=<?php echo $spiel?>&bildpfad=<?php echo $bildpfad?><?php if (!empty($_GET['sprache'])) echo '&sprache='.$sprache;?>" target="_self">
                 <frameset framespacing="0" border="false" frameborder="0" rows="80,*,92">
                     <frame name="rahmen18" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=28&bildpfad=<?php echo $bildpfad?>" target="_self">
                     <frame name="rahmen19" scrolling="no" marginwidth="0" marginheight="0" noresize src="aufbau.php?fu=29&bildpfad=<?php echo $bildpfad?>" target="_self">
@@ -352,7 +355,7 @@ if ($fuid==2) {
                             <center>
                                 <table border="0" cellspacing="0" cellpadding="3" width="100%">
                                     <tr>
-                                        <td width="100%"><img src="../lang/<?php echo $_GET['sprache']?>/topics/dieimperien.gif" border="0" width="185" height="52"></td>
+                                        <td width="100%"><img src="../lang/<?php echo $sprache?>/topics/dieimperien.gif" border="0" width="185" height="52"></td>
                                         <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_1.gif" border="0" width="41" height="41"></center></td>
                                         <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_2.gif" border="0" width="41" height="41"></center></td>
                                         <td><center><img src="<?php echo $bildpfad?>/aufbau/rang_3.gif" border="0" width="41" height="41"></center></td>

--- a/inhalt/uebersicht_imperien.php
+++ b/inhalt/uebersicht_imperien.php
@@ -184,7 +184,7 @@ if ($fuid==3) {
     include ("inc.header.php");
         if ($spieler==int_get('spid')) {
             $spalte="spieler_".$spieler."_rassename";
-            $zeiger_temp= @mysql_query("UPDATE $skrupel_spiele set $spalte='".$_POST['neu_name']."' where id=$spiel");
+            $zeiger_temp= @mysql_query("UPDATE $skrupel_spiele set $spalte='".str_post('neu_name','SQLSAFE')."' where id=$spiel");
             ?>
             <script language=JavaScript>
                 window.location='uebersicht_imperien.php?fu=1&uid=<?php echo $uid?>&sid=<?php echo $sid?>';


### PR DESCRIPTION
Quasi als 2.Teil des Commits zur Prüfung der übergebenen Zahlenwerte werden jetzt auch alle anderen Usereingaben überprüft, um SQL-Injections / Remote File Inclusions und sowas endlich auszumerzen.

Verwendet werden dazu die nunmehr modifizierten Funktionen str_get und str_post aus der hilfsfunktionen-Datei.
Die einzelnen alten Bearbeitungen der Strings verstreut im Code wurden nun (soweit es sich fürs erste anbot) in diese Funktionen eingebaut und im Code ausdokumentiert.

Bei den String-Eingaben werden nun vier Kategorien/Modi unterschieden, die die wichtigsten Filter-Fälle abdecken:
- 'SHORTNAME': erlaubt sind alphanumerische Sachen und der Underscore (Verwendung u.a. bei Rassen (romulan, borg, ...), Sprachen, uid, sid und Struktur (gala_4))
- 'PATHNAME': hier sind zusätzlich . und / für Pfadangaben erlaubt (taucht aktuell nur beim Bildpfad auf)
- 'DEFAULT': Alphanumerisches und die Sonderzeichen _ & : ;  - für diverse Stellen (koord (z.B. 4-2) bei der Sektorwahl zum Setzen neuer Spieler, Html-kodierte Submit-Buttons, Routing-Daten (durch : getrennte Zahlenlisten) )
- 'SQLSAFE': die obigen Fälle sind natürlich auch 'SQL-sicher', aber dieser Fall wird speziell für das Eintragen allgemeiner Felder (Nachrichten, Forenposts, Spieler-Email usw.) in die DB genommen; grundsätzlich sind hier alle Eingaben erlaubt, aber sie werden entsprechend escaped
  -- aktuell werden dort " ' \ sogar wie zuvor im Code verstreut noch entfernt auch wenn ein entsprechendes Escapen ja bereits ausreichen sollte (kann man bei Bedarf jetzt ja sehr leicht zentral ändern)
  -- bei bestimmten Variablen (thema, beitrag, offenbarung) werden Html-Zeilenumbrüche mittels nl2br wie früher eingefügt (konsequent wäre es natürlich in Zukunft die html-Zeilenumbrüche gar nicht mehr in der DB zu speichern (wie derzeit beim Logbuch), aber im jetzigen Schritt wollte ich diesbzgl. möglichst alles unverändert lassen, damit alte DB-Einträge keine Anzeigeprobleme machen)

Weitere Codeänderungen im GET/POST-Kontext:
- einige zuvor unentdeckte Zahlenwerte wurden entsprechend mit int_get / int_post bedacht
- der zusätzliche preg_match Filter für Sprachen (index.php) wurde strenger gemacht: vorher waren völlig beliebige Strings zulässig, die min. zwei aufeinanderfolgende Buchstaben hatten... gemeint war sicher, daß nur zwei aufeinanderfolgende Buchstaben erlaubt sind ;)
- beim Subfunk: Code zum Ermitteln der Sprache des Empfängers vereinfacht
