### PR TITLE
inhalt/inc.host_func.php geändert

### DIFF
--- a/inhalt/inc.host_func.php
+++ b/inhalt/inc.host_func.php
@@ -334,6 +334,7 @@ function rzufallstring() {
 define('ONLY_LETTERS',0);
 define('WITH_NUMBERS', 1);
 define('WITH_SPECIAL_CHARACTERS', 2);
+if (! function_exists("zufallstring")){
 function zufallstring($size = 20, $url = ONLY_LETTERS){
   mt_srand();
   $pool = 'abcdefghijklmnopqrstuvwxyz';
@@ -350,4 +351,4 @@ function zufallstring($size = 20, $url = ONLY_LETTERS){
     $salt .= $pool[mt_rand(0, $pool_size - 1)];
   }
   return $salt; 
-} 
+} }


### PR DESCRIPTION
Beim Rundenende kann es zu einem schwerwiegenden Fehler kommen, da die Funktion zufallstring() ebenfalls in der inc.hilfsfunktionen definiert ist. Dem soll durch eine zusätzliche Abfrage vorgebeugt werden.
